### PR TITLE
Adds STARTTLS support to SMTP notifications

### DIFF
--- a/isso/core.py
+++ b/isso/core.py
@@ -117,7 +117,7 @@ class Config:
         "reload = off", "profile = off",
         "[smtp]",
         "username = ", "password = ",
-        "host = localhost", "port = 465", "ssl = on",
+        "host = localhost", "port = 465", "security = ssl",
         "to = ", "from = ",
         "[guard]",
         "enabled = true",

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -57,8 +57,11 @@ class SMTP(object):
             uwsgi.spooler = spooler
 
     def __enter__(self):
-        klass = (smtplib.SMTP_SSL if self.conf.getboolean('ssl') else smtplib.SMTP)
+        klass = (smtplib.SMTP_SSL if self.conf.get('security') == 'ssl' else smtplib.SMTP)
         self.client = klass(host=self.conf.get('host'), port=self.conf.getint('port'))
+
+        if self.conf.get('security') == 'starttls':
+            self.client.starttls();
 
         if self.conf.get('username') and self.conf.get('password'):
             self.client.login(self.conf.get('username'),


### PR DESCRIPTION
This changes the `ssl = on|off` option to `security = ssl|starttls|none`
I can update this PR if you prefer some other way of doing this.

Note: I'm not very familiar with Python; any pointers are appreciated.
