### PR TITLE
default smtp to port=587 and security=starttls

### DIFF
--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -158,8 +158,8 @@ also can moderate (=activate or delete) comments. Don't forget to configure
     username =
     password =
     host = localhost
-    port = 465
-    security = ssl
+    port = 587
+    security = starttls
     to =
     from =
 

--- a/docs/isso.example.cfg
+++ b/docs/isso.example.cfg
@@ -78,12 +78,12 @@ password =
 host = localhost
 
 # SMTP port
-port = 465
+port = 587
 
 # use a secure connection to the server, possible values: "none", "starttls"
 # or "ssl". Python 2.X probably does not validate certificates (needs
 # research). But you should use a dedicated email account anyways.
-security = ssl
+security = starttls
 
 # recipient address, e.g. your email address
 to =

--- a/isso/core.py
+++ b/isso/core.py
@@ -117,7 +117,7 @@ class Config:
         "reload = off", "profile = off",
         "[smtp]",
         "username = ", "password = ",
-        "host = localhost", "port = 465", "security = ssl",
+        "host = localhost", "port = 587", "security = tls",
         "to = ", "from = ",
         "[guard]",
         "enabled = true",


### PR DESCRIPTION
port 465 + TLS is not a good default setting .It's mainly a [deprecated and microsoft-specific port](http://en.wikipedia.org/wiki/SMTPS). StartTLS has been preferred for years.
