### PR TITLE
Docs update: forward url protocol in sample nginx configs

### DIFF
--- a/docs/docs/configuration/setup.rst
+++ b/docs/docs/configuration/setup.rst
@@ -19,6 +19,8 @@ originating from CORS_. Also, privacy-protecting browser addons such as
         location /isso {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Script-Name /isso;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_pass http://localhost:8080;
         }
     }

--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -111,6 +111,7 @@ configuration looks like this:
             proxy_pass http://localhost:8080;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 


### PR DESCRIPTION
This forwards the url scheme (http or https) to isso. So, correct links are generated in notifications.
