### PR TITLE
Update config sample to work with SQLAlchemy

### DIFF
--- a/share/isso.conf
+++ b/share/isso.conf
@@ -3,9 +3,9 @@
 
 [general]
 
-# file location to the SQLite3 database, highly recommended to change this
-# location to a persistent location, e.g. /var/lib/isso/comments.db.
-dbpath = :memory:
+# Address of the database
+# see docs.sqlalchemy.org/en/rel_0_9/core/engines.html for the syntax
+dbpath = sqlite://
 
 # required to dispatch multiple websites, not used otherwise.
 name =


### PR DESCRIPTION
SA syntax for in memory database is `sqlite://`
