### PR TITLE
bug fixed: was trying to remove an unexisting span.votes

### DIFF
--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -155,8 +155,10 @@ define(["app/dom", "app/utils", "app/config", "app/api", "app/jade", "app/i18n",
             // update vote counter, but hide if votes sum to 0
             var votes = function (value) {
                 var span = $("span.votes", footer);
-                if (span === null && value !== 0) {
-                    footer.prepend($.new("span.votes", value));
+                if (span === null) {
+                    if (value !== 0) {
+                        footer.prepend($.new("span.votes", value));
+                    }
                 } else {
                     if (value === 0) {
                         span.remove();


### PR DESCRIPTION
The bug was invisible to the user but if you opened a web console you could see a JS error.
You can reproduce this bug on the demo page by:
1) writing a new comment
2) trying to upvote or downvote your comment
What happened then was:
1) Not changing anything to the vote count (that's OK you can't upvote or downvote your own comments).
2) Triggering a new JS error: TypeError: n is null
