### PR TITLE
Don't skip threads with empty id tags during migration

### DIFF
--- a/isso/migrate.py
+++ b/isso/migrate.py
@@ -118,10 +118,6 @@ class Disqus(object):
         for i, thread in enumerate(tree.findall(Disqus.ns + 'thread')):
             progress.update(i, thread.find(Disqus.ns + 'id').text)
 
-            # skip (possibly?) duplicate, but empty thread elements
-            if thread.find(Disqus.ns + 'id').text is None:
-                continue
-
             id = thread.attrib.get(Disqus.internals + 'id')
             if id in res:
                 self.threads.add(id)


### PR DESCRIPTION
The assumption of the comment is false. The id tag of a thread can be empty on non-empty threads, too! (At least this is the case for the Disqus export file I exported recently.)

In my data, all id tags are empty, which caused isso to skip _all_ threads.

Removing these lines fixed the bug. After the change all comments were imported successfully.

This patch fixes #135.
