### PR TITLE
correct order by in sql request

### DIFF
--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -114,8 +114,12 @@ class Comments:
                 sql.append('AND comments.parent=?')
                 sql_args.append(parent)
 
-        sql.append('ORDER BY ? ASC')
-        sql_args.append(order_by)
+        # custom sanitization
+        if order_by not in ['id', 'created', 'modified', 'likes', 'dislikes']:
+            order_by = 'id'
+        sql.append('ORDER BY ')
+        sql.append(order_by)
+        sql.append(' ASC')
 
         if limit:
             sql.append('LIMIT ?')


### PR DESCRIPTION
I tried to substitute ORDER BY ? ASC into ORDER BY ? DESC in the fetch request, only to discover that the current code was not correct. The only reason why this was not a visible bug is that Isso currently does not use this capability to order comments differently and the output order is the database order.

Explanations on what did not work: http://stackoverflow.com/questions/6995497/find-by-sql-and-single-quotes-in-an-order-by-clause

I decided to use a strong custom sanitization because we don't need anything more complicated here and that's the safer way.
