### PR TITLE
Don't lose comment content if it failed to create

### DIFF
--- a/isso/js/app/api.js
+++ b/isso/js/app/api.js
@@ -90,7 +90,13 @@ define(["app/lib/promise", "app/globals"], function(Q, globals) {
     var create = function(tid, data) {
         var deferred = Q.defer();
         curl("POST", endpoint + "/new?" + qs({uri: tid || location}), JSON.stringify(data),
-            function (rv) { deferred.resolve(JSON.parse(rv.body)); });
+            function (rv) {
+                if (rv.status === 201) {
+                    deferred.resolve(JSON.parse(rv.body));
+                } else {
+                    deferred.reject(rv.body);
+                }
+            });
         return deferred.promise;
     };
 


### PR DESCRIPTION
Hello,

This is a really minor change whose object is to avoid losing a possibly long comment just because the server rejected it.
Common reasons for rejections include ill-formed e-mail address and ill-formed website URL.

For now, I am not adding an error message to let the user know that there was an error but that is something I can add if we discuss it first.

Additionally, this pull request solves partly my concern in #131
