### PR TITLE
Vagrant support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DOCS_HTML_DST := docs/_build/html
 all: man js site
 
 init:
-	(cd isso/js; bower install almond requirejs requirejs-text jade)
+	(cd isso/js; bower --allow-root install almond requirejs requirejs-text jade)
 
 check:
 	@echo "Python 2.x"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,4 +83,5 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: $bootstrap
 
+  config.vm.post_up_message = "Browse to http://isso-dev.local/demo/index.html to start."
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This is the Vagrant config file for setting up an environment for Isso development.
+# It requires:
+#
+# * Vagrant (http://vagrantup.com)
+# * A VM engine, like VirtualBox (http://virtualbox.org)
+# * The Vagrant-Hostmanager plugin (https://github.com/smdahlen/vagrant-hostmanager)
+#
+# With them installed, cd into this directory and do 'vagrant up'. It's possible Vagrant will
+# ask for your root password so it can update your /etc/hosts file. Once it's happily churning out
+# console output, go get a coffee :)
+#
+# The resulting VM should be accessible at http://isso-dev.local/ so you can try the demo page out.
+# Edit files in your checkout as usual. If you need to look at log files and stuff, 'vagrant ssh'
+# to get into the VM. Useful info about it:
+#
+# * Running Ubuntu 14.04
+# * Isso is running on uWSGI via port 8080
+# * Actual webserver is Apache2, using mod_proxy_uwsgi to talk to uWSGI
+# * uWSGI log file is /tmp/uwsgi.log
+# * Isso DB file is /tmp/isso/comments.db
+# * Isso log file is /tmp/isso/isso.log
+#
+# Enjoy!
+
+$bootstrap = <<BOOTSTRAP
+  apt-get update
+  apt-get install -y apache2 curl build-essential python-setuptools python-dev sqlite3 git python-pip
+  a2enmod proxy
+  service apache2 restart
+
+  curl -sL https://deb.nodesource.com/setup | bash -
+  apt-get install -y nodejs
+
+  npm install -g bower requirejs uglifyjs jade
+
+  cd /vagrant
+  python setup.py develop
+  make init
+  make js
+
+  ln -s /vagrant/isso/demo /var/www/isso
+
+  pip install uwsgi
+  mkdir -p /tmp/isso/spool
+
+  uwsgi --socket 127.0.0.1:8080 --master --processes 4 --cache2 name=hash,items=1024,blocksize=32 --spooler /tmp/isso/spool --module isso.run --env ISSO_SETTINGS=/vagrant/share/isso-dev.conf --daemonize /tmp/uwsgi.log  
+  chmod a+r /tmp/uwsgi.log
+  
+  apt-get install libapache2-mod-proxy-uwsgi
+
+  cp /vagrant/share/isso-dev.local.apache-conf /etc/apache2/sites-available/isso-dev.local.conf
+  a2ensite isso-dev.local
+  a2dissite 000-default
+  service apache2 restart
+
+BOOTSTRAP
+
+Vagrant.configure(2) do |config|
+
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.vm.box = "ubuntu/trusty32"
+
+  config.vm.hostname = 'isso-dev.local'
+  config.vm.network "private_network", type: "dhcp"
+
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.ignore_private_ip = false
+  config.hostmanager.include_offline = true
+  config.hostmanager.ip_resolver = proc do |machine|
+    result = ""
+    machine.communicate.execute("ifconfig eth1") do |type, data|
+      result << data if type == :stdout
+    end
+    (ip = /inet addr:(\d+\.\d+\.\d+\.\d)/.match(result)) && ip[1]
+  end
+
+  config.vm.provision "shell", inline: $bootstrap
+
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ $bootstrap = <<BOOTSTRAP
   pip install uwsgi
   mkdir -p /tmp/isso/spool
 
-  uwsgi --socket 127.0.0.1:8080 --master --processes 4 --cache2 name=hash,items=1024,blocksize=32 --spooler /tmp/isso/spool --module isso.run --env ISSO_SETTINGS=/vagrant/share/isso-dev.conf --daemonize /tmp/uwsgi.log  
+  uwsgi --socket 127.0.0.1:8080 --master --processes 4 --cache2 name=hash,items=1024,blocksize=32 --spooler /tmp/isso/spool --module isso.run --env ISSO_SETTINGS=/vagrant/share/isso-dev.conf --daemonize /tmp/uwsgi.log --py-autoreload 1 
   chmod a+r /tmp/uwsgi.log
   
   apt-get install libapache2-mod-proxy-uwsgi

--- a/isso/demo/index.html
+++ b/isso/demo/index.html
@@ -8,7 +8,7 @@
 		<div id="wrapper" style="width: 900px; text-align: left; margin-left: auto; margin-right: auto;">
 			<h2><a href="index.html">Isso Demo</a></h2>
 			
-			<script	src="isso/js/embed.min.js"></script>
+			<script	src="../js/embed.min.js"></script>
 
 			<section id="isso-thread" data-title="Isso Test"></section>
 		</div>

--- a/isso/demo/index.html
+++ b/isso/demo/index.html
@@ -7,7 +7,8 @@
 	<div id="page" style="text-align:center;">
 		<div id="wrapper" style="width: 900px; text-align: left; margin-left: auto; margin-right: auto;">
 			<h2><a href="index.html">Isso Demo</a></h2>
-			<script	src="../js/embed.min.js"></script>
+			
+			<script	src="isso/js/embed.min.js"></script>
 
 			<section id="isso-thread" data-title="Isso Test"></section>
 		</div>

--- a/share/isso-dev.conf
+++ b/share/isso-dev.conf
@@ -1,0 +1,31 @@
+# Isso configuration file
+# vim: set filetype=ini
+
+# These are the settings used to run Isso inside of the vagrant-powered developer setup.
+
+[general]
+
+dbpath = /tmp/isso/comments.db
+host = http://isso-dev.local/
+max-age = 15m
+notify = stdout
+log-file = /tmp/isso/isso.log
+
+[moderation]
+enabled = false
+purge-after = 30d
+
+[server]
+profile = off
+
+[guard]
+enabled = false
+
+[markup]
+options = strikethrough, autolink, fenced_code, no_intra_emphasis
+allowed-elements =
+allowed-attributes =
+
+[hash]
+salt = Eech7co8Ohloopo9Ol6baimi
+algorithm = pbkdf2

--- a/share/isso-dev.local.apache-conf
+++ b/share/isso-dev.local.apache-conf
@@ -1,0 +1,14 @@
+<VirtualHost *:80>
+	ServerName isso-dev.local
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/isso/
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	ProxyPass /isso/ uwsgi://127.0.0.1:8080/
+
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/share/isso-dev.local.apache-conf
+++ b/share/isso-dev.local.apache-conf
@@ -7,7 +7,7 @@
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-	ProxyPass /isso/ uwsgi://127.0.0.1:8080/
+	ProxyPass / uwsgi://127.0.0.1:8080/
 
 </VirtualHost>
 


### PR DESCRIPTION
I've created a Vagrantfile to make it easy to get a test environment up and running with the demo page - Vagrant will spin up a VM with node.js, uWSGI, Apache2, and register everything such that you can immediately view the demo page at http://isso-dev.local/ and start trying out code changes.

Doesn't affect the end user but should make it nicer for me to work with :) maybe helpful for other people too?