### PR TITLE
Fix npm uglifyjs missing package error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ $bootstrap = <<BOOTSTRAP
   curl -sL https://deb.nodesource.com/setup | bash -
   apt-get install -y nodejs
 
-  npm install -g bower requirejs uglifyjs jade
+  npm install -g bower requirejs uglify-js jade
 
   cd /vagrant
   python setup.py develop


### PR DESCRIPTION
uglifyjs has been [unpublished](https://www.npmjs.com/package/uglifyjs). Instead use uglify-js.