### PR TITLE
Make sure the key used for signing is a string

### DIFF
--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -84,7 +84,7 @@ class Isso(object):
 
         self.conf = conf
         self.db = db.SQLite3(conf.get('general', 'dbpath'), conf)
-        self.signer = URLSafeTimedSerializer(self.db.preferences.get("session-key"))
+        self.signer = URLSafeTimedSerializer(str(self.db.preferences.get("session-key")))
         self.markup = html.Markup(conf.section('markup'))
         self.hasher = hash.new(conf.section("hash"))
 


### PR DESCRIPTION
Fix #159 

---

For unknown reasons, the secret key on my machine is a buffer type variable. This patch assures this is a string.