### PR TITLE
Save the session-key as a unicode string in the db

### DIFF
--- a/isso/db/preferences.py
+++ b/isso/db/preferences.py
@@ -7,7 +7,7 @@ import binascii
 class Preferences:
 
     defaults = [
-        ("session-key", binascii.b2a_hex(os.urandom(24))),
+        ("session-key", binascii.b2a_hex(os.urandom(24)).decode('utf-8')),
     ]
 
     def __init__(self, db):


### PR DESCRIPTION
The session-key should be saved as a string, not a byte string.