### PR TITLE
Correct auth without password or username.

### DIFF
--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -72,7 +72,7 @@ class SMTP(object):
 
         username = self.conf.get('username')
         password = self.conf.get('password')
-        if username is not None and password is not None:
+        if username and password:
             if PY2K:
                 username = username.encode('ascii')
                 password = password.encode('ascii')


### PR DESCRIPTION
If no username is set, returns an empty string. So the test `username is
not None` is always True. Idem for password. This can lead to
authentication problems. This commit fixes the test to `if username and
password` as it was in the previous version.

Full error message:
```
2015-03-07 16:04:03,456 ERROR: unable to connect to SMTP server
Traceback (most recent call last):
  File "/home/blog/comments/lib/python2.7/site-packages/isso/ext/notifications.py", line 42, in __init__
    with self:
  File "/home/blog/comments/lib/python2.7/site-packages/isso/ext/notifications.py", line 75, in __enter__
    self.client.login(username, password)
  File "/usr/lib64/python2.7/smtplib.py", line 578, in login
    raise SMTPException("SMTP AUTH extension not supported by server.")
SMTPException: SMTP AUTH extension not supported by server.
```