### PR TITLE
http: use requests to handle redirects

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,5 +47,8 @@ In chronological order:
 * Daniel Gräber <https://github.com/albohlabs>
   * Added ansible for provisioning
 
+* Ben Boeckel <mathstuf@gmail.com>
+  * httplib -> requests to handle redirects
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/isso/tests/fixtures.py
+++ b/isso/tests/fixtures.py
@@ -25,7 +25,7 @@ class JSONClient(Client):
 
 class Dummy:
 
-    status = 200
+    status_code = 200
 
     def __enter__(self):
         return self

--- a/isso/utils/http.py
+++ b/isso/utils/http.py
@@ -2,28 +2,29 @@
 
 import socket
 
-try:
-    import httplib
-except ImportError:
-    import http.client as httplib
+import requests
 
 from isso import dist
 from isso.wsgi import urlsplit
 
 
 class curl(object):
-    """Easy to use wrapper around :module:`httplib`.  Use as context-manager
+    """Easy to use wrapper around :module:`requests`.  Use as context-manager
     so we can close the response properly.
 
     .. code-block:: python
 
         with http.curl('GET', 'http://localhost:8080', '/') as resp:
             if resp:  # may be None if request failed
-                return resp.status
+                return resp.status_code
     """
 
     headers = {
         "User-Agent": "Isso/{0} (+http://posativ.org/isso)".format(dist.version)
+    }
+    methods = {
+        "GET": requests.get,
+        "HEAD": requests.head
     }
 
     def __init__(self, method, host, path, timeout=3):
@@ -35,19 +36,12 @@ class curl(object):
     def __enter__(self):
 
         host, port, ssl = urlsplit(self.host)
-        http = httplib.HTTPSConnection if ssl else httplib.HTTPConnection
-
-        self.con = http(host, port, timeout=self.timeout)
 
         try:
-            self.con.request(self.method, self.path, headers=self.headers)
-        except (httplib.HTTPException, socket.error):
-            return None
-
-        try:
-            return self.con.getresponse()
-        except (httplib.HTTPException, socket.timeout, socket.error):
+            return self.methods[self.method](self.host + self.path,
+                    timeout=self.timeout, headers=self.headers)
+        except (KeyError, requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             return None
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.con.close()
+        pass

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -169,8 +169,8 @@ class API(object):
         with self.isso.lock:
             if uri not in self.threads:
                 with http.curl('GET', local("origin"), uri) as resp:
-                    if resp and resp.status == 200:
-                        uri, title = parse.thread(resp.read(), id=uri)
+                    if resp and resp.status_code == 200:
+                        uri, title = parse.thread(resp.content, id=uri)
                     else:
                         return NotFound('URI does not exist')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-requires = ['itsdangerous', 'misaka', 'html5lib<0.9999']
+requires = ['itsdangerous', 'misaka', 'html5lib<0.9999', 'requests']
 
 if (3, 0) <= sys.version_info < (3, 3):
     raise SystemExit("Python 3.0, 3.1 and 3.2 are not supported")


### PR DESCRIPTION
Raw use of httplib does not respect the 3xx status codes which may
result in 200 at the end. Use requests to handle any redirects and loop
detection.

---
Looking again, it wasn't so much. Addresses #193.