### PR TITLE
Make Vagrant actually work

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,5 +47,8 @@ In chronological order:
 * Daniel Gräber <https://github.com/albohlabs>
   * Added ansible for provisioning
 
+* Nick Hu <https://github.com/NickHu>
+  * Fix Vagrantfile
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -32,6 +32,7 @@
         - supervisor
         - sqlite3
         - nodejs
+        - libffi-dev
 
     - name: NPM | Install packages
       npm: name={{ item }} global=yes


### PR DESCRIPTION
`vagrant up` dies without `libffi-dev` installed