### PR TITLE
Add configuration to make email a required field

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,5 +47,8 @@ In chronological order:
 * Daniel Gräber <https://github.com/albohlabs>
   * Added ansible for provisioning
 
+* Nick Hu <https://github.com/NickHu>
+  * Added configuration to require email addresses (no validation)
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -10,6 +10,7 @@ preferably in the script tag which embeds the JS:
             data-isso-css="true"
             data-isso-lang="ru"
             data-isso-reply-to-self="false"
+            data-isso-require-email="false"
             data-isso-max-comments-top="10"
             data-isso-max-comments-nested="5"
             data-isso-reveal-on-click="5"
@@ -57,6 +58,11 @@ data-isso-reply-to-self
 -----------------------
 
 Set to `true` when spam guard is configured with `reply-to-self = true`.
+
+data-isso-require-email
+-----------------------
+
+Set to `true` when spam guard is configured with `require-email = true`.
 
 data-isso-max-comments-top and data-isso-max-comments-nested
 ------------------------------------------------------------

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -217,6 +217,7 @@ for IPv4, ``/48`` for IPv6).
     ratelimit = 2
     direct-reply = 3
     reply-to-self = false
+    require-email = false
 
 enabled
     enable guard, recommended in production. Not useful for debugging
@@ -233,6 +234,12 @@ reply-to-self
     allow commenters to reply to their own comments when they could still edit
     the comment. After the editing timeframe is gone, commenters can reply to
     their own comments anyways.
+
+    Do not forget to configure the client.
+
+require-email
+    force commenters to enter a value into the email field. No validation is
+    performed on the provided value.
 
     Do not forget to configure the client.
 

--- a/isso/db/spam.py
+++ b/isso/db/spam.py
@@ -49,6 +49,7 @@ class Guard:
             if len(rv) >= self.conf.getint("direct-reply"):
                 return False, "%i direct responses to %s" % (len(rv), uri)
 
+        # block replies to self unless :param:`reply-to-self` is enabled
         elif self.conf.getboolean("reply-to-self") == False:
             rv = self.db.execute([
                 'SELECT id FROM comments WHERE'
@@ -60,6 +61,10 @@ class Guard:
 
             if len(rv) > 0:
                 return False, "edit time frame is still open"
+
+        # require email if :param:`require-email` is enabled
+        if self.conf.getboolean("require-email") and not comment.get("email"):
+            return False, "email address required but not provided"
 
         return True, ""
 

--- a/isso/js/app/config.js
+++ b/isso/js/app/config.js
@@ -5,6 +5,7 @@ define(function() {
         "css": true,
         "lang": (navigator.language || navigator.userLanguage).split("-")[0],
         "reply-to-self": false,
+        "require-email": false,
         "max-comments-top": "inf",
         "max-comments-nested": 5,
         "reveal-on-click": 5,

--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -24,8 +24,21 @@ define(["app/dom", "app/utils", "app/config", "app/api", "app/jade", "app/i18n",
                 $(".textarea", this).focus();
                 return false;
             }
+            if (config["require-email"] &&
+                $("[name='email']", this).value.length <= 0)
+            {
+              $("[name='email']", this).focus();
+              return false;
+            }
             return true;
         };
+
+        // email is not optional if this config parameter is set
+        if (config["require-email"])
+        {
+          $("[name='email']", el).placeholder =
+            $("[name='email']", el).placeholder.replace(/ \(.*\)/, "");
+        }
 
         // submit form, initialize optional fields with `null` and reset form.
         // If replied to a comment, remove form completely.

--- a/isso/tests/test_guard.py
+++ b/isso/tests/test_guard.py
@@ -35,7 +35,7 @@ class TestGuard(unittest.TestCase):
     def setUp(self):
         self.path = tempfile.NamedTemporaryFile().name
 
-    def makeClient(self, ip, ratelimit=2, direct_reply=3, self_reply=False):
+    def makeClient(self, ip, ratelimit=2, direct_reply=3, self_reply=False, require_email=False):
 
         conf = config.load(os.path.join(dist.location, "share", "isso.conf"))
         conf.set("general", "dbpath", self.path)
@@ -44,11 +44,13 @@ class TestGuard(unittest.TestCase):
         conf.set("guard", "ratelimit", str(ratelimit))
         conf.set("guard", "direct-reply", str(direct_reply))
         conf.set("guard", "reply-to-self", "1" if self_reply else "0")
+        conf.set("guard", "require-email", "1" if require_email else "0")
 
         class App(Isso, core.Mixin):
             pass
 
         app = App(conf)
+
         app.wsgi_app = FakeIP(app.wsgi_app, ip)
 
         return Client(app, Response)
@@ -113,3 +115,8 @@ class TestGuard(unittest.TestCase):
         self.assertEqual(client.post("/new?uri=test", data=self.data).status_code, 201)
         self.assertEqual(client.post("/new?uri=test", data=payload(1)).status_code, 201)
         self.assertEqual(client.post("/new?uri=test", data=payload(2)).status_code, 201)
+
+    def testRequireEmail(self):
+
+        #TODO
+        pass

--- a/isso/tests/test_guard.py
+++ b/isso/tests/test_guard.py
@@ -118,5 +118,15 @@ class TestGuard(unittest.TestCase):
 
     def testRequireEmail(self):
 
-        #TODO
-        pass
+        payload = lambda email: json.dumps({"text": "...", "email": email})
+
+        client = self.makeClient("127.0.0.1", ratelimit=4, require_email=False) 
+        client_strict = self.makeClient("127.0.0.2", ratelimit=4, require_email=True) 
+
+        # if we don't require email
+        self.assertEqual(client.post("/new?uri=test", data=payload("")).status_code, 201)
+        self.assertEqual(client.post("/new?uri=test", data=payload("test@me.more")).status_code, 201)
+
+        # if we do require email
+        self.assertEqual(client_strict.post("/new?uri=test", data=payload("")).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=test", data=payload("test@me.more")).status_code, 201)

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -130,6 +130,10 @@ direct-reply = 3
 # their own comments anyways. Do not forget to configure the client.
 reply-to-self = false
 
+# require the commenter to enter an email address (note: no validation is
+# done on the provided address). Do not forget to configure the client.
+require-email = false
+
 
 [markup]
 # Customize markup and sanitized HTML. Currently, only Markdown (via Misaka) is


### PR DESCRIPTION
This patch adds a parameter to make requiring an email address configurable.

Could probably be improved by:

* ~~write tests~~
* using HTML5 form validation
* not using a nasty regex substitute to remove `(required)` from the placeholder (or internationalised equivalent)