### PR TITLE
Pin misaka to 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-requires = ['itsdangerous', 'misaka', 'html5lib<0.9999']
+requires = ['itsdangerous', 'misaka>=1.0,<2.0', 'html5lib<0.9999']
 
 if (3, 0) <= sys.version_info < (3, 3):
     raise SystemExit("Python 3.0, 3.1 and 3.2 are not supported")


### PR DESCRIPTION
With the release of misaka 2.0, new users experienced breakage when
2.0 was installed (#208).

2.0 has a slightly different API, and Python 2.6 support in 2.0 is not
yet released. #212 contains the update to 2.0, so this change should
only be a stopgap until the next misaka release with Py2.6 support.