### PR TITLE
Fix issue #27 on override thread discovery with custom data-attributes

### DIFF
--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -107,11 +107,10 @@ Enable or disable voting feature on the client side.
 data-isso-id
 ------------
 
-Broken – do not use. https://github.com/posativ/isso/issues/27
-
-Set a custom thread id, defaults to current URI. If you use a comment counter,
-add this attribute to the link tag, too.
+Set a custom thread id, defaults to current URI. This attribute needs
+to be used with the data-title attribute in order to work.
+If you use a comment counter, add this attribute to the link tag, too.
 
 .. code-block:: html
 
-    <section data-isso-id="test.abc" id="isso-thread"></section>
+    <section data-title="Yay!" data-isso-id="test.abc" id="isso-thread"></section>

--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -57,7 +57,8 @@ define(["app/dom", "app/utils", "app/config", "app/api", "app/jade", "app/i18n",
             api.create($("#isso-thread").getAttribute("data-isso-id"), {
                 author: author, email: email, website: website,
                 text: utils.text($(".textarea", el).innerHTML),
-                parent: parent || null
+                parent: parent || null,
+                title: $("#isso-thread").getAttribute("data-title") || null
             }).then(function(comment) {
                 $(".textarea", el).innerHTML = "";
                 $(".textarea", el).blur();

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -75,7 +75,7 @@ class API(object):
                   'mode', 'created', 'modified', 'likes', 'dislikes', 'hash'])
 
     # comment fields, that can be submitted
-    ACCEPT = set(['text', 'author', 'website', 'email', 'parent'])
+    ACCEPT = set(['text', 'author', 'website', 'email', 'parent', 'title'])
 
     VIEWS = [
         ('fetch',   ('GET', '/')),
@@ -168,11 +168,14 @@ class API(object):
 
         with self.isso.lock:
             if uri not in self.threads:
-                with http.curl('GET', local("origin"), uri) as resp:
-                    if resp and resp.status == 200:
-                        uri, title = parse.thread(resp.read(), id=uri)
-                    else:
-                        return NotFound('URI does not exist')
+                if 'title' not in data:
+                    with http.curl('GET', local("origin"), uri) as resp:
+                        if resp and resp.status == 200:
+                            uri, title = parse.thread(resp.read(), id=uri)
+                        else:
+                            return NotFound('URI does not exist %s')
+                else:
+                    title = data['title']
 
                 thread = self.threads.new(uri, title)
                 self.signal("comments.new:new-thread", thread)


### PR DESCRIPTION
Hello,

Here is a fix for the use of data-isso-id.
The problem was that thread ids needs to be URL because of an http curl used to check title of the page. 
I changed this behaviour a little by saying that if you provide a title (using the data-title documented in the client configuration), we don't need to send a curl request to get the title and just grab it. Incidently it makes custom thread id work since the curl to get the title is the only reason thread id is an URL (at least I didn't was any other need for this constraint).

Tell me if any changes needs to be made to the PR.