### PR TITLE
fix "optional" in zh translations

### DIFF
--- a/isso/js/app/i18n/zh_CN.js
+++ b/isso/js/app/i18n/zh_CN.js
@@ -1,8 +1,8 @@
 define({
-    "postbox-text": "在此输入评论(最少3个字符)",
-    "postbox-author": "名字(可选)",
-    "postbox-email": "E-mail(可选)",
-    "postbox-website": "网站(可选)",
+    "postbox-text": "在此输入评论 (最少3个字符)",
+    "postbox-author": "名字 (可选)",
+    "postbox-email": "E-mail (可选)",
+    "postbox-website": "网站 (可选)",
     "postbox-submit": "提交",
 
     "num-comments": "1条评论\n{{ n }}条评论",

--- a/isso/js/app/i18n/zh_TW.js
+++ b/isso/js/app/i18n/zh_TW.js
@@ -1,8 +1,8 @@
 define({
     "postbox-text": "在此輸入留言（至少3個字元）",
-    "postbox-author": "名稱（非必填）",
-    "postbox-email": "電子信箱（非必填）",
-    "postbox-website": "個人網站（非必填）",
+    "postbox-author": "名稱 (非必填)",
+    "postbox-email": "電子信箱 (非必填)",
+    "postbox-website": "個人網站 (非必填)",
     "postbox-submit": "送出",
 
     "num-comments": "1則留言\n{{ n }}則留言",


### PR DESCRIPTION
This fixes #262
Probably there are better ways to handle "(optional)" by not using regexes.