### PR TITLE
update doc to reflect 5ce48de

### DIFF
--- a/docs/docs/extras/advanced-integration.rst
+++ b/docs/docs/extras/advanced-integration.rst
@@ -21,5 +21,5 @@ Now, either include `count.min.js` if you want to show only the comment count
 (e.g. on an index page) or `embed.min.js` for the full comment client (see
 :doc:`../quickstart`); do not mix both.
 
-You can have as many comments counters as you want in a page but be aware that it
-implies one `GET` request per comment anchor.
+You can have as many comments counters as you want in a page, and they will be
+merged into a single `GET` request.


### PR DESCRIPTION
It looks like multiple comment counters now result in a single `GET` request (a very good thing!) as of 5ce48de.  This updates the docs to reflect that.