### PR TITLE
Have client read out shared settings from server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,16 @@ Changelog for Isso
   cookies. (#700, ix5)
 - Fallback for SameSite header depending on whether host is served over https
   or http (#700, ix5)
+- Have client read out shared settings from server. (#311, pellenilsson)
+  This affects these settings for which ``data-isso-*`` values will be ignored:
+
+    [general]
+    reply-notifications
+    gravatar
+    [guard]
+    reply-to-self
+    require-author
+    require-email
 
 0.12.4 (2021-02-03)
 -------------------

--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -11,10 +11,6 @@ preferably in the script tag which embeds the JS:
             data-isso-css="true"
             data-isso-css-url="null"
             data-isso-lang="ru"
-            data-isso-reply-to-self="false"
-            data-isso-require-author="false"
-            data-isso-require-email="false"
-            data-isso-reply-notifications="false"
             data-isso-max-comments-top="10"
             data-isso-max-comments-nested="5"
             data-isso-reveal-on-click="5"
@@ -128,26 +124,6 @@ languages. The language is configured by its `ISO 639-1
 You find a list of all supported languages on `GitHub
 <https://github.com/posativ/isso/tree/master/isso/js/app/i18n>`_.
 
-data-isso-reply-to-self
------------------------
-
-Set to `true` when spam guard is configured with `reply-to-self = true`.
-
-data-isso-require-author
-------------------------
-
-Set to `true` when spam guard is configured with `require-author = true`.
-
-data-isso-require-email
------------------------
-
-Set to `true` when spam guard is configured with `require-email = true`.
-
-data-isso-reply-notifications
------------------------------
-
-Set to `true` when reply notifications is configured with `reply-notifications = true`.
-
 data-isso-max-comments-top and data-isso-max-comments-nested
 ------------------------------------------------------------
 
@@ -164,7 +140,9 @@ Number of comments to reveal on clicking the "X Hidden" link.
 data-isso-avatar
 ----------------
 
-Enable or disable avatar generation.
+Enable or disable avatar generation. Ignored if gravatar is enabled on
+server side, since gravatars will take precedence and disable avatar
+generation.
 
 data-isso-avatar-bg
 -------------------
@@ -178,14 +156,6 @@ Set avatar foreground color. Up to 8 colors are possible. The default color
 scheme is based in `this color palette <http://colrd.com/palette/19308/>`_.
 Multiple colors must be separated by space. If you use less than eight colors
 and not a multiple of 2, the color distribution is not even.
-
-data-isso-gravatar
-------------------
-
-Uses gravatar images instead of generating svg images. You have to set
-"data-isso-avatar" to **false** when you want to use this. Otherwise
-both the gravatar and avatar svg image will show up. Please also set
-option "gravatar" to **true** in the server configuration...
 
 data-isso-vote
 --------------
@@ -212,3 +182,38 @@ data-isso-feed
 Enable or disable the addition of a link to the feed for the comment
 thread. The link will only be valid if the appropriate setting, in
 ``[rss]`` section, is also enabled server-side.
+
+
+
+Deprecated Client Settings
+==========================
+
+In earlier versions the following settings had to mirror the
+corresponding settings in the server configuration, but they are now
+read out from the server automatically.
+
+data-isso-reply-to-self
+-----------------------
+
+Set to `true` when spam guard is configured with `reply-to-self = true`.
+
+data-isso-require-author
+------------------------
+
+Set to `true` when spam guard is configured with `require-author = true`.
+
+data-isso-require-email
+-----------------------
+
+Set to `true` when spam guard is configured with `require-email = true`.
+
+data-isso-reply-notifications
+-----------------------------
+
+Set to `true` when reply notifications is configured with `reply-notifications = true`.
+
+data-isso-gravatar
+------------------
+
+Set to `true` when gravatars are enabled with `gravatar = true` in the
+server configuration.

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -95,8 +95,6 @@ reply-notifications
     It is highly recommended to also turn on moderation when enabling this
     setting, as Isso can otherwise be easily exploited for sending spam.
 
-    Do not forget to configure the client accordingly.
-
 log-file
     Log console messages to file instead of standard out.
 
@@ -297,19 +295,13 @@ reply-to-self
     the comment. After the editing timeframe is gone, commenters can reply to
     their own comments anyways.
 
-    Do not forget to configure the `client <client>`_ accordingly
-
 require-author
     force commenters to enter a value into the author field. No validation is
     performed on the provided value.
 
-    Do not forget to configure the `client <client>`_ accordingly.
-
 require-email
     force commenters to enter a value into the email field. No validation is
     performed on the provided value.
-
-    Do not forget to configure the `client <client>`_ accordingly.
 
 .. _configure-markup:
 

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -41,8 +41,10 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
             feedLinkWrapper.appendChild(feedLink);
             isso_thread.append(feedLinkWrapper);
         }
+        // Note: Not appending the isso.Postbox here since it relies
+        // on the config object populated by elements fetched from the server,
+        // and the call to fetch those is in fetchComments()
         isso_thread.append(heading);
-        isso_thread.append(new isso.Postbox(null));
         isso_thread.append('<div id="isso-root"></div>');
     }
 
@@ -57,6 +59,19 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
             config["max-comments-top"],
             config["max-comments-nested"]).then(
             function (rv) {
+                for (var setting in rv.config) {
+                    if (setting in config && config[setting] != rv.config[setting]) {
+                        console.log("Isso: Client value '%s' for setting '%s' overridden by server value '%s'.\n" +
+                                    "Since Isso version 0.12.6, 'data-isso-%s' is only configured via the server " +
+                                    "to keep client and server in sync",
+                                    config[setting], setting, rv.config[setting], setting);
+                    }
+                    config[setting] = rv.config[setting]
+                }
+
+                // Finally, create Postbox with configs fetched from server
+                isso_thread.append(new isso.Postbox(null));
+
                 if (rv.total_replies === 0) {
                     heading.textContent = i18n.translate("no-comments");
                     return;

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -138,6 +138,17 @@ class API(object):
         except NoOptionError:
             self.trusted_proxies = []
 
+        # These configuration records can be read out by client
+        self.public_conf = {}
+        self.public_conf["reply-to-self"] = isso.conf.getboolean("guard", "reply-to-self")
+        self.public_conf["require-email"] = isso.conf.getboolean("guard", "require-email")
+        self.public_conf["require-author"] = isso.conf.getboolean("guard", "require-author")
+        self.public_conf["reply-notifications"] = isso.conf.getboolean("general", "reply-notifications")
+        self.public_conf["gravatar"] = isso.conf.getboolean("general", "gravatar")
+
+        if self.public_conf["gravatar"]:
+            self.public_conf["avatar"] = False
+
         self.guard = isso.db.guard
         self.threads = isso.db.threads
         self.comments = isso.db.comments
@@ -833,7 +844,8 @@ class API(object):
             'id': root_id,
             'total_replies': reply_counts[root_id],
             'hidden_replies': reply_counts[root_id] - len(root_list),
-            'replies': self._process_fetched_list(root_list, plain)
+            'replies': self._process_fetched_list(root_list, plain),
+            'config': self.public_conf
         }
         # We are only checking for one level deep comments
         if root_id is None:


### PR DESCRIPTION
Some settings (reply-to-self and require-email) always need to be set to the same value on server and client side for correct operation. This change removes the need for such redundant information by having the client read out those settings from the server.

According to the docs this should be true for require-author as well, but that settings doesn't seem to be implemented.