### PR TITLE
Better configure options for Chinese language

### DIFF
--- a/isso/js/app/i18n.js
+++ b/isso/js/app/i18n.js
@@ -2,8 +2,8 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
         "app/i18n/en", "app/i18n/fa", "app/i18n/fi", "app/i18n/fr",
         "app/i18n/hr", "app/i18n/ru", "app/i18n/it", "app/i18n/eo",
         "app/i18n/sv", "app/i18n/nl", "app/i18n/el_GR", "app/i18n/es",
-        "app/i18n/vi", "app/i18n/zh_CN"],
-        function(config, bg, cs, de, en, fa, fi, fr, hr, ru, it, eo, sv, nl, el, es, vi, zh) {
+        "app/i18n/vi", "app/i18n/zh_CN", "app/i18n/zh_TW"],
+        function(config, bg, cs, de, en, fa, fi, fr, hr, ru, it, eo, sv, nl, el, es, vi, zh_CN, zh_TW) {
 
     "use strict";
 
@@ -23,7 +23,8 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
         case "sv":
         case "nl":
         case "vi":
-        case "zh":
+        case "zh_CN":
+        case "zh_TW":
             return function(msgs, n) {
                 return msgs[n === 1 ? 0 : 1];
             };
@@ -70,7 +71,8 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
         sv: sv,
         nl: nl,
         vi: vi,
-        zh: zh
+        zh_CN: zh_CN,
+        zh_TW: zh_TW
     };
 
     var plural = pluralforms(lang);

--- a/isso/js/app/i18n.js
+++ b/isso/js/app/i18n.js
@@ -2,8 +2,8 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
         "app/i18n/en", "app/i18n/fa", "app/i18n/fi", "app/i18n/fr",
         "app/i18n/hr", "app/i18n/ru", "app/i18n/it", "app/i18n/eo",
         "app/i18n/sv", "app/i18n/nl", "app/i18n/el_GR", "app/i18n/es",
-        "app/i18n/vi", "app/i18n/zh_CN", "app/i18n/zh_TW"],
-        function(config, bg, cs, de, en, fa, fi, fr, hr, ru, it, eo, sv, nl, el, es, vi, zh_CN, zh_TW) {
+        "app/i18n/vi", "app/i18n/zh_CN", "app/i18n/zh_CN", "app/i18n/zh_TW"],
+        function(config, bg, cs, de, en, fa, fi, fr, hr, ru, it, eo, sv, nl, el, es, vi, zh, zh_CN, zh_TW) {
 
     "use strict";
 
@@ -23,6 +23,7 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
         case "sv":
         case "nl":
         case "vi":
+        case "zh":
         case "zh_CN":
         case "zh_TW":
             return function(msgs, n) {
@@ -71,6 +72,7 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
         sv: sv,
         nl: nl,
         vi: vi,
+        zh: zh_CN,
         zh_CN: zh_CN,
         zh_TW: zh_TW
     };


### PR DESCRIPTION
Allow the user configure language to "zh", "zh_CN", "zh_TW", and make them work as expected.