### PR TITLE
Highlighting for author comments

### DIFF
--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -90,6 +90,7 @@ class Isso(object):
         self.signer = URLSafeTimedSerializer(self.db.preferences.get("session-key"))
         self.markup = html.Markup(conf.section('markup'))
         self.hasher = hash.new(conf.section("hash"))
+        self.author = self.hasher.uhash(conf.get('general', 'author'));
 
         super(Isso, self).__init__(conf)
 

--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -23,6 +23,11 @@
     color: #AAA;
 }
 
+.isso-highlight {
+    padding: 0em 0em 0.5em 0.5em;
+    background-color: rgba(200, 200, 200, 0.4);
+}
+
 .isso-comment {
     max-width: 68em;
     padding-top: 0.95em;

--- a/isso/js/app/api.js
+++ b/isso/js/app/api.js
@@ -177,6 +177,20 @@ define(["app/lib/promise", "app/globals"], function(Q, globals) {
         return deferred.promise;
     };
 
+    var author = function() {
+        var deferred = Q.defer();
+        curl("GET", endpoint + "/author", null, function(rv) {
+                if (rv.status === 200) {
+                    deferred.resolve(JSON.parse(rv.body));
+                } else if (rv.status === 404) {
+                    deferred.resolve({author: ""});
+                } else {
+                    deferred.reject(rv.body);
+                }
+            });
+        return deferred.promise;
+    };
+
     var like = function(id) {
         var deferred = Q.defer();
         curl("POST", endpoint + "/id/" + id + "/like", null,
@@ -201,6 +215,7 @@ define(["app/lib/promise", "app/globals"], function(Q, globals) {
         view: view,
         fetch: fetch,
         count: count,
+        author: author,
         like: like,
         dislike: dislike
     };

--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -5,6 +5,8 @@ define(["app/dom", "app/utils", "app/config", "app/api", "app/jade", "app/i18n",
 
     "use strict";
 
+    api.author().then(function(rv) { config["blogauthor"] = rv; });
+
     var Postbox = function(parent) {
 
         var localStorage = utils.localStorageImpl,

--- a/isso/js/app/text/comment.jade
+++ b/isso/js/app/text/comment.jade
@@ -1,4 +1,4 @@
-div(class='isso-comment' id='isso-#{comment.id}')
+div(class=(comment.hash == conf.blogauthor) ? 'isso-comment isso-highlight' : 'isso-comment' id='isso-#{comment.id}')
     if conf.avatar
         div(class='avatar')
             svg(data-hash='#{comment.hash}')

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -82,6 +82,7 @@ class API(object):
         ('new',     ('POST', '/new')),
         ('count',   ('GET', '/count')),
         ('counts',  ('POST', '/count')),
+        ('author',  ('GET', '/author')),
         ('view',    ('GET', '/id/<int:id>')),
         ('edit',    ('PUT', '/id/<int:id>')),
         ('delete',  ('DELETE', '/id/<int:id>')),
@@ -479,6 +480,15 @@ class API(object):
             raise BadRequest("JSON must be a list of URLs")
 
         return JSON(self.comments.count(*data), 200)
+
+    def author(self, environ, request):
+
+        rv = self.isso.author
+
+        if rv == "":
+            raise NotFound
+
+        return JSON(rv, 200)
 
     def preview(self, environment, request):
         data = request.get_json()

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -26,6 +26,10 @@ name =
 #
 host =
 
+# The email address you use on this website.
+# This will identify you as the author of the site via highlighted comments.
+author =
+
 # time range that allows users to edit/remove their own comments.
 # It supports years, weeks, days, hours, minutes, seconds.
 # 3h45m12s equals to 3 hours, 45 minutes and 12 seconds.


### PR DESCRIPTION
I've completed #82 and made it into a feature rather than a manual hack.

Under the [general] section in isso.conf there is now an `author` variable that users can set to an email which they use on their websites to differentiate themselves from other commenters.

![issoauthor](https://cloud.githubusercontent.com/assets/3059508/25255031/0ec70876-2629-11e7-86d3-b754630487ce.png)

There were a few additions needed to get this done. 
1. Hash the author address on startup.
2. Extend the api to allow `/author` requests (which returns the hash).
3. Append the api response to the `conf` struct on the client side.
4. Compare the comment and blog author hashes, append a new css selector `isso-highlight`.

I guess this implementation has no issue with using a users' IP too, although I haven't tested that. In fact, I haven't written any test in yet. Thought I'd get some feedback to see if this was something of interest first.