### PR TITLE
Implement customizable sorting

### DIFF
--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -22,6 +22,7 @@ preferably in the script tag which embeds the JS:
             data-isso-avatar-fg="#9abf88 #5698c4 #e279a3 #9163b6 ..."
             data-isso-vote="true"
             data-isso-vote-levels=""
+            data-isso-sorting="oldest"
             data-isso-feed="false"
             src="/prefix/js/embed.js"></script>
 
@@ -149,6 +150,11 @@ For example, the value `"-5,5"` will cause each `isso-comment` to be given one o
 - `isso-vote-level-2` for scores of `5` and greater
 
 These classes can then be used to customize the appearance of comments (eg. put a star on popular comments)
+
+data-isso-sorting
+-----------------
+
+This can be set either to `oldest` (the default) or `newest`.
 
 data-isso-feed
 --------------

--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -154,7 +154,24 @@ These classes can then be used to customize the appearance of comments (eg. put 
 data-isso-sorting
 -----------------
 
-This can be set either to `oldest` (the default) or `newest`.
+A comma-separated list of thread sorting methods that are applied in the
+specified order.
+
+Possible sorting methods:
+
+- `newest`: Bring newest comments to the top
+- `oldest`: Bring oldest comments to the top
+- `upvotes`: Bring most liked comments to the top
+
+You can combine sorting methods. If you specify `upvotes,newest`, then comments
+will be sorted by upvotes, and comments with the same number of upvotes will be
+sorted by date (newest first).
+
+Note that only the top level threads are sorted according to this
+configuration. The thread replies are still sorted in chronological order
+(oldest first), so that they can be read from top to bottom.
+
+Default sorting is `oldest`.
 
 data-isso-feed
 --------------

--- a/isso/js/app/config.js
+++ b/isso/js/app/config.js
@@ -18,6 +18,7 @@ define(function() {
                       "#be5168", "#f19670", "#e4bf80", "#447c69"].join(" "),
         "vote": true,
         "vote-levels": null,
+        "sorting": "oldest",
         "feed": false
     };
 

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -63,6 +63,12 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
 
                 var lastcreated = 0;
                 var count = rv.total_replies;
+
+                // Correct sorting of comments
+                if (config["sorting"] === "newest") {
+                    rv.replies.reverse();
+                }
+
                 rv.replies.forEach(function(comment) {
                     isso.insert(comment, false);
                     if (comment.created > lastcreated) {


### PR DESCRIPTION
In the first commit, I implemented sorting by oldest or newest. The implementation is very simple and would fix #265 and #319. I then extended the sorting algorithm in the second commit to support multiple sorting methods and added the "upvote" sorter. With this, #4 is also fixed.

To see how it works, the updated part of the documentation:

> A comma-separated list of thread sorting methods that are applied in the
> specified order.
> 
> Possible sorting methods:
> 
> - `newest`: Bring newest comments to the top
> - `oldest`: Bring oldest comments to the top
> - `upvotes`: Bring most liked comments to the top
> 
> You can combine sorting methods. If you specify `upvotes,newest`, then comments
> will be sorted by upvotes, and comments with the same number of upvotes will be
> sorted by date (newest first).
> 
> Note that only the top level threads are sorted according to this
> configuration. The thread replies are still sorted in chronological order
> (oldest first), so that they can be read from top to bottom.
>
> Default sorting is `oldest`.

I kept the default sorting at `oldest`, but you might want to change it to `upvotes,newest`.