### PR TITLE
Support for used-defined log formats

### DIFF
--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -45,6 +45,7 @@ session key and hostname. Here are the default values for this section:
     max-age = 15m
     notify = stdout
     log-file =
+    log-format = %%(asctime)s %%(levelname)s: %%(message)s
 
 dbpath
     file location to the SQLite3 database, highly recommended to change this
@@ -91,8 +92,12 @@ notify
 log-file
     Log console messages to file instead of standard out.
 
+log-format
+    Log format to use. Available keys are described in LOGRECORD_
+
 
 .. _CORS: https://developer.mozilla.org/en/docs/HTTP/Access_control_CORS
+.. _LOGRECORD: https://docs.python.org/3/library/logging.html#logrecord-attributes
 
 
 Moderation

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -249,11 +249,9 @@ def main():
         logger.propagate = False
         logging.getLogger("werkzeug").propagate = False
 
-    fmt = conf.get("general", "log-format")
-    if fmt:
-        formatter = logging.Formatter(fmt)
-        for handler in logger.handlers:
-            handler.setFormatter(formatter)
+    formatter = logging.Formatter(conf.get("general", "log-format"))
+    for handler in logger.handlers:
+        handler.setFormatter(formatter)
 
     if not any(conf.getiter("general", "host")):
         logger.error("No website(s) configured, Isso won't work.")

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -249,6 +249,12 @@ def main():
         logger.propagate = False
         logging.getLogger("werkzeug").propagate = False
 
+    fmt = conf.get("general", "log-format")
+    if fmt:
+        formatter = logging.Formatter(fmt)
+        for handler in logger.handlers:
+            handler.setFormatter(formatter)
+
     if not any(conf.getiter("general", "host")):
         logger.error("No website(s) configured, Isso won't work.")
         sys.exit(1)

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -46,6 +46,8 @@ notify = stdout
 # Log console messages to file instead of standard out.
 log-file =
 
+# Log format
+log-format = %%(asctime)s %%(levelname)s: %%(message)s
 
 [moderation]
 # enable comment moderation queue. This option only affects new comments.


### PR DESCRIPTION
Hi,

currently only the messages are logged to the log file, which makes it difficult to inspect, as there are no dates or severities to grep for.
I patched the code so that they are included, and also let the user can provide a custom format in the config file.
