### PR TITLE
Admin interface >> add host to comment URI

### DIFF
--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -178,7 +178,7 @@ function send_edit(com_id, hash) {
       {% if order_by == "tid" %}
         {% if thread_id != comment.tid %}
           {% set thread_id = comment.tid %}
-          <h2 class="thread-title">{{comment.title}} (<a href="{{comment.uri}}">{{comment.uri}}</a>)</h2>
+          <h2 class="thread-title">{{comment.title}} (<a href="{{host}}{{comment.uri}}">{{host}}{{comment.uri}}</a>)</h2>
         {% endif %}
       {% endif %}
 <div class='isso-comment' id='isso-{{comment.id}}'>
@@ -190,7 +190,7 @@ function send_edit(com_id, hash) {
     <div class='text-wrapper'>
       <div class='isso-comment-header' role='meta'>
         {% if order_by != "tid" %}
-          <div>Thread: {{comment.title}} (<a href="{{comment.uri}}">{{comment.uri}}</a>)</div><br />
+          <div>Thread: {{comment.title}} (<a href="{{host}}{{comment.uri}}">{{host}}{{comment.uri}}</a>)</div><br />
         {% endif %}
         {% if comment.author %}
           <span class='author' id="isso-author-{{comment.id}}">{{comment.author}}</span>

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -872,8 +872,9 @@ class API(object):
             comments_enriched.append(comment)
         comment_mode_count = self.comments.count_modes()
         max_page = int(sum(comment_mode_count.values()) / 100)
+        host = self.isso.conf.get("general", "host")
         return render_template('admin.html', comments=comments_enriched,
                                page=int(page), mode=int(mode),
                                conf=self.conf, max_page=max_page,
                                counts=comment_mode_count,
-                               order_by=order_by, asc=asc)
+                               order_by=order_by, asc=asc, host=host)


### PR DESCRIPTION
@blatinier Add the host to comment URI.
If ISSO URL is located here: comments.example.com
And BLOG URL is located here: example.com
And host within share/isso.conf is that: example.com
Then the comment URI was providing wrong URLs with the relative path /MY_BLOG_URL 
Now it will be: example.com/MY_BLOG_URL based on the host provided in isso.conf