### PR TITLE
fix: admin and demo view redirect issue

### DIFF
--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -843,14 +843,19 @@ class API(object):
         return JSON({'text': self.isso.render(data["text"])}, 200)
 
     def demo(self, env, req):
-        return redirect(get_current_url(env) + '/index.html')
+        return redirect(
+            get_current_url(env, strip_querystring=True) + '/index.html'
+        )
 
     def login(self, env, req):
         data = req.form
         password = self.isso.conf.get("general", "admin_password")
         if data['password'] and data['password'] == password:
-            response = redirect(get_current_url(
-                env, host_only=True) + '/admin')
+            response = redirect(re.sub(
+                r'/login$',
+                '/admin',
+                get_current_url(env, strip_querystring=True)
+            ))
             cookie = functools.partial(dump_cookie,
                                        value=self.isso.sign({"logged": True}),
                                        expires=datetime.now() + timedelta(1))


### PR DESCRIPTION
If someone visit demo page with querystrng, like `http://isso.example.com/demo?a` , there would be an error caused by too many redirects. So before the url string was joint, querystring should be striped.

After login the admin page, the actual redirect url would be `http://isso.example.com//admin` . There is an extra `/` and the browser would just goto `http://isso.example.com/` other than `http://isso.example.com/admin` , which causes a 'Bad Request'.

this commit fix both 2 bugs above.