### PR TITLE
Provide a multi-staged Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# First, compile JS stuff
+FROM node
+WORKDIR /src/
+COPY . .
+RUN npm install -g requirejs uglify-js jade bower
+RUN make init js
+
+# Second, create virtualenv
+FROM python:3-stretch
+WORKDIR /src/
+COPY --from=0 /src .
+RUN apt-get -qqy update && apt-get -qqy install python3-dev sqlite3
+RUN python3 -m venv /isso \
+ && . /isso/bin/activate \
+ && python setup.py install \
+ && pip install gunicorn
+
+# Third, create final repository
+FROM python:3-slim-stretch
+WORKDIR /isso/
+COPY --from=1 /isso .
+
+# Configuration
+VOLUME /db /config
+EXPOSE 8080
+ENV ISSO_SETTINGS /config/isso.cfg
+CMD ["/isso/bin/gunicorn", "-b", "0.0.0.0:8080", "-w", "4", "--preload", "isso.run"]
+
+# Example of use:
+#
+# docker build -t isso .
+# docker run -it --rm -v /opt/isso:/config -v /opt/isso:/db -v $PWD:$PWD isso /isso/bin/isso -c \$ISSO_SETTINGS import disqus.xml
+# docker run -d --rm --name isso -p 8080:8080 -v /opt/isso:/config -v /opt/isso:/db isso

--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -149,7 +149,18 @@ Prebuilt Packages
 * Fedora: https://copr.fedoraproject.org/coprs/jujens/isso/ — copr
   repository. Built from Pypi, includes a systemctl unit script.
 
-* Docker Image: https://registry.hub.docker.com/u/bl4n/isso/
+Build a Docker image
+--------------------
+
+You can get a Docker image by running ``docker build . -t
+isso``. Assuming you have your configuration in ``/opt/isso``, you can
+use the following command to spawn the Docker container:
+
+.. code-block:: sh
+
+    ~> docker run -d --rm --name isso -p 127.0.0.1:8080:8080 -v /opt/isso:/config -v /opt/isso:/db isso
+
+Then, you can use a reverse proxy to expose port 8080.
 
 Install from Source
 -------------------


### PR DESCRIPTION
Many of the Docker images on hub.docker.com are outdated. The one
specified in the documentation doesn't exist anymore. We provide a
decent Dockerfile to build our own Docker image.

This uses a multi-stage build to avoid polluting the final image with
the intermediate artifacts. The final image is 155 MB. It should be
possible to squeeze it even more by using Alpine Linux for the last
two parts instead of Stretch.

The service is using gunicorn. The user is expected to complete the
installation with a reverse proxy configuration.