### PR TITLE
html: add nofollow/noopener to links

### DIFF
--- a/isso/tests/test_html.py
+++ b/isso/tests/test_html.py
@@ -65,7 +65,7 @@ class TestHTML(unittest.TestCase):
         examples = [
             ('Look: <img src="..." />', 'Look: '),
             ('<a href="http://example.org/">Ha</a>',
-             '<a href="http://example.org/">Ha</a>'),
+             '<a href="http://example.org/" rel="nofollow noopener">Ha</a>'),
             ('<a href="sms:+1234567890">Ha</a>', '<a>Ha</a>'),
             ('<p style="visibility: hidden;">Test</p>', '<p>Test</p>'),
             ('<script>alert("Onoe")</script>', 'alert("Onoe")')]
@@ -93,4 +93,4 @@ class TestHTML(unittest.TestCase):
         })
         renderer = html.Markup(conf.section("markup")).render
         self.assertEqual(renderer("http://example.org/ and sms:+1234567890"),
-                         '<p><a href="http://example.org/">http://example.org/</a> and sms:+1234567890</p>')
+                         '<p><a href="http://example.org/" rel="nofollow noopener">http://example.org/</a> and sms:+1234567890</p>')

--- a/isso/utils/html.py
+++ b/isso/utils/html.py
@@ -50,6 +50,11 @@ def sanitize(tokenizer, document):
 
     if HTML5LIB_VERSION > HTML5LIB_SIMPLETREE:
         builder = "etree"
+
+        for link in domtree.findall(".//{http://www.w3.org/1999/xhtml}a"):
+            if link.get('href', None):
+                link.set("rel", "nofollow noopener")
+
     else:
         builder = "simpletree"
 


### PR DESCRIPTION
"nofollow" is a deterrent for spammers: they cannot put links and hope
to increase their SEO when all these links have the nofollow
relationship.

"noopener" is a security for links opening a new window. They ensure
the target cannot control us.

Fix #373