### PR TITLE
api: add /feed API to get an Atom feed for an URI

### DIFF
--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -20,7 +20,8 @@ preferably in the script tag which embeds the JS:
             data-isso-avatar-bg="#f0f0f0"
             data-isso-avatar-fg="#9abf88 #5698c4 #e279a3 #9163b6 ..."
             data-isso-vote="true"
-            data-vote-levels=""
+            data-isso-vote-levels=""
+            data-isso-feed="false"
             src="/prefix/js/embed.js"></script>
 
 Furthermore you can override the automatic title detection inside
@@ -125,3 +126,10 @@ For example, the value `"-5,5"` will cause each `isso-comment` to be given one o
 - `isso-vote-level-2` for scores of `5` and greater
 
 These classes can then be used to customize the appearance of comments (eg. put a star on popular comments)
+
+data-isso-feed
+--------------
+
+Enable or disable the addition of a link to the feed for the comment
+thread. The link will only be valid if the appropriate setting, in
+``[rss]`` section, is also enabled server-side.

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -308,6 +308,27 @@ algorithm
     Arguments have to be in that order, but can be reduced to `pbkdf2:4096`
     for example to override the iterations only.
 
+.. _configure-rss:
+
+RSS
+---
+
+Isso can provide an Atom feed for each comment thread. Users can use
+them to subscribe to comments and be notified of changes. Atom feeds
+are enabled as soon as there is a base URL defined in this section.
+
+.. code-block:: ini
+
+    [rss]
+    base =
+    limit = 100
+
+base
+    base URL to use to build complete URI to pages (by appending the URI from Isso)
+
+limit
+    number of most recent comments to return for a thread
+
 Appendum
 --------
 

--- a/docs/docs/extras/api.rst
+++ b/docs/docs/extras/api.rst
@@ -185,3 +185,16 @@ uri :
 
 returns an integer
     
+Get Atom feed
+-------------
+
+Get an Atom feed of comments for thread `uri`:
+
+.. code-block:: text
+
+    GET /feed?uri=%2Fhello-world%2F
+    
+uri :
+    URI to get comments for, required.
+
+Returns an XML document as the Atom feed.

--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -15,6 +15,14 @@
     color: #555;
     font-weight: bold;
 }
+#isso-thread > .isso-feedlink {
+    float: right;
+    padding-left: 1em;
+}
+#isso-thread > .isso-feedlink > a {
+    font-size: 0.8em;
+    vertical-align: bottom;
+}
 #isso-thread .textarea {
     min-height: 58px;
     outline: 0;
@@ -119,10 +127,12 @@
     color: gray !important;
     clear: left;
 }
+.isso-feedlink,
 .isso-comment > div.text-wrapper > .isso-comment-footer a {
     font-weight: bold;
     text-decoration: none;
 }
+.isso-feedlink:hover,
 .isso-comment > div.text-wrapper > .isso-comment-footer a:hover {
     color: #111111 !important;
     text-shadow: #aaaaaa 0 0 1px !important;
@@ -152,6 +162,7 @@
 .isso-postbox {
     max-width: 68em;
     margin: 0 auto 2em;
+    clear: right;
 }
 .isso-postbox > .form-wrapper {
     display: block;

--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -159,7 +159,8 @@ class Comments:
         for item in rv:
             yield dict(zip(fields_comments + fields_threads, item))
 
-    def fetch(self, uri, mode=5, after=0, parent='any', order_by='id', limit=None):
+    def fetch(self, uri, mode=5, after=0, parent='any',
+              order_by='id', asc=1, limit=None):
         """
         Return comments for :param:`uri` with :param:`mode`.
         """
@@ -181,7 +182,8 @@ class Comments:
             order_by = 'id'
         sql.append('ORDER BY ')
         sql.append(order_by)
-        sql.append(' ASC')
+        if not asc:
+            sql.append(' DESC')
 
         if limit:
             sql.append('LIMIT ?')

--- a/isso/js/app/api.js
+++ b/isso/js/app/api.js
@@ -191,6 +191,10 @@ define(["app/lib/promise", "app/globals"], function(Q, globals) {
         return deferred.promise;
     };
 
+    var feed = function(tid) {
+        return endpoint + "/feed?" + qs({uri: tid || location});
+    }
+
     return {
         endpoint: endpoint,
         salt: salt,
@@ -202,6 +206,7 @@ define(["app/lib/promise", "app/globals"], function(Q, globals) {
         fetch: fetch,
         count: count,
         like: like,
-        dislike: dislike
+        dislike: dislike,
+        feed: feed
     };
 });

--- a/isso/js/app/config.js
+++ b/isso/js/app/config.js
@@ -15,7 +15,8 @@ define(function() {
         "avatar-fg": ["#9abf88", "#5698c4", "#e279a3", "#9163b6",
                       "#be5168", "#f19670", "#e4bf80", "#447c69"].join(" "),
         "vote": true,
-        "vote-levels": null
+        "vote-levels": null,
+        "feed": false
     };
 
     var js = document.getElementsByTagName("script");

--- a/isso/js/app/i18n/en.js
+++ b/isso/js/app/i18n/en.js
@@ -7,6 +7,7 @@ define({
 
     "num-comments": "One Comment\n{{ n }} Comments",
     "no-comments": "No Comments Yet",
+    "atom-feed": "Atom feed",
 
     "comment-reply": "Reply",
     "comment-edit": "Edit",

--- a/isso/js/app/i18n/fr.js
+++ b/isso/js/app/i18n/fr.js
@@ -6,6 +6,7 @@ define({
     "postbox-submit": "Soumettre",
     "num-comments": "{{ n }} commentaire\n{{ n }} commentaires",
     "no-comments": "Aucun commentaire pour l'instant",
+    "atom-feed": "Flux Atom",
     "comment-reply": "Répondre",
     "comment-edit": "Éditer",
     "comment-save": "Enregistrer",

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -27,11 +27,13 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
             return console.log("abort, #isso-thread is missing");
         }
 
-        var feedLink = $.new('a', i18n.translate('atom-feed'));
-        var feedLinkWrapper = $.new('span.isso-feedlink');
-        feedLink.href = api.feed($("#isso-thread").getAttribute("data-isso-id"));
-        feedLinkWrapper.append(feedLink);
-        $("#isso-thread").append(feedLinkWrapper);
+        if (config["feed"]) {
+            var feedLink = $.new('a', i18n.translate('atom-feed'));
+            var feedLinkWrapper = $.new('span.isso-feedlink');
+            feedLink.href = api.feed($("#isso-thread").getAttribute("data-isso-id"));
+            feedLinkWrapper.append(feedLink);
+            $("#isso-thread").append(feedLinkWrapper);
+        }
         $("#isso-thread").append($.new('h4'));
         $("#isso-thread").append(new isso.Postbox(null));
         $("#isso-thread").append('<div id="isso-root"></div>');

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -27,6 +27,11 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
             return console.log("abort, #isso-thread is missing");
         }
 
+        var feedLink = $.new('a', i18n.translate('atom-feed'));
+        var feedLinkWrapper = $.new('span.isso-feedlink');
+        feedLink.href = api.feed($("#isso-thread").getAttribute("data-isso-id"));
+        feedLinkWrapper.append(feedLink);
+        $("#isso-thread").append(feedLinkWrapper);
         $("#isso-thread").append($.new('h4'));
         $("#isso-thread").append(new isso.Postbox(null));
         $("#isso-thread").append('<div id="isso-root"></div>');

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -345,7 +345,7 @@ class TestComments(unittest.TestCase):
 
         self.post('/new?uri=%2Fpath%2F', data=json.dumps({'text': 'First'}))
         self.post('/new?uri=%2Fpath%2F',
-                  data=json.dumps({'text': 'First', 'parent': 1}))
+                  data=json.dumps({'text': '*Second*', 'parent': 1}))
 
         rv = self.get('/feed?uri=%2Fpath%2F')
         self.assertEqual(rv.status_code, 200)
@@ -354,7 +354,7 @@ class TestComments(unittest.TestCase):
         data = re.sub('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z',
                       '2018-04-01T10:00:00Z', data)
         self.assertEqual(data, """<?xml version=\'1.0\' encoding=\'utf-8\'?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"><updated>2018-04-01T10:00:00Z</updated><id>tag:example.org,2018:/isso/thread/path/</id><title>Comments for example.org/path/</title><entry><id>tag:example.org,2018:/isso/1/2</id><title>Comment #2</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-2" /><content type="html">First</content><thr:in-reply-to href="https://example.org/path/#isso-1" ref="tag:example.org,2018:/isso/1/1" /></entry><entry><id>tag:example.org,2018:/isso/1/1</id><title>Comment #1</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-1" /><content type="html">First</content></entry></feed>""")
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"><updated>2018-04-01T10:00:00Z</updated><id>tag:example.org,2018:/isso/thread/path/</id><title>Comments for example.org/path/</title><entry><id>tag:example.org,2018:/isso/1/2</id><title>Comment #2</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-2" /><content type="html">&lt;p&gt;&lt;em&gt;Second&lt;/em&gt;&lt;/p&gt;</content><thr:in-reply-to href="https://example.org/path/#isso-1" ref="tag:example.org,2018:/isso/1/1" /></entry><entry><id>tag:example.org,2018:/isso/1/1</id><title>Comment #1</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-1" /><content type="html">&lt;p&gt;First&lt;/p&gt;</content></entry></feed>""")
 
     def testCounts(self):
 

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import os
 import json
+import re
 import tempfile
 import unittest
 
@@ -30,6 +31,7 @@ class TestComments(unittest.TestCase):
         fd, self.path = tempfile.mkstemp()
         conf = config.load(os.path.join(dist.location, "share", "isso.conf"))
         conf.set("general", "dbpath", self.path)
+        conf.set("general", "host", "https://example.org")
         conf.set("guard", "enabled", "off")
         conf.set("hash", "algorithm", "none")
 
@@ -323,6 +325,28 @@ class TestComments(unittest.TestCase):
             rv.pop(key)
 
         self.assertListEqual(list(rv.keys()), [])
+
+    def testFeedEmpty(self):
+        rv = self.get('/feed?uri=%2Fpath%2Fnothing')
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.headers['ETag'], '"empty"')
+        data = rv.data.decode('utf-8')
+        self.assertEqual(data, """<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"><updated>1970-01-01T01:00:00Z</updated><id>tag:example.org,2018:/isso/thread/path/nothing</id><title>Comments for example.org/path/nothing</title></feed>""")
+
+    def testFeed(self):
+        self.post('/new?uri=%2Fpath%2F', data=json.dumps({'text': 'First'}))
+        self.post('/new?uri=%2Fpath%2F',
+                  data=json.dumps({'text': 'First', 'parent': 1}))
+
+        rv = self.get('/feed?uri=%2Fpath%2F')
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.headers['ETag'], '"1-2"')
+        data = rv.data.decode('utf-8')
+        data = re.sub('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z',
+                      '2018-04-01T10:00:00Z', data)
+        self.assertEqual(data, """<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"><updated>2018-04-01T10:00:00Z</updated><id>tag:example.org,2018:/isso/thread/path/</id><title>Comments for example.org/path/</title><entry><id>tag:example.org,2018:/isso/1/2</id><title>Comment #2</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-2" /><content type="html">First</content><thr:in-reply-to href="https://example.org/path/#isso-1" ref="tag:example.org,2018:/isso/1/1" /></entry><entry><id>tag:example.org,2018:/isso/1/1</id><title>Comment #1</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-1" /><content type="html">First</content></entry></feed>""")
 
     def testCounts(self):
 

--- a/isso/utils/__init__.py
+++ b/isso/utils/__init__.py
@@ -132,3 +132,10 @@ class JSONResponse(Response):
         kwargs["content_type"] = "application/json"
         super(JSONResponse, self).__init__(
             json.dumps(obj).encode("utf-8"), *args, **kwargs)
+
+
+class XMLResponse(Response):
+    def __init__(self, obj, *args, **kwargs):
+        kwargs["content_type"] = "text/xml"
+        super(XMLResponse, self).__init__(
+            obj, *args, **kwargs)

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -854,11 +854,15 @@ class API(object):
     """
     @requires(str, 'uri')
     def feed(self, environ, request, uri):
+        conf = self.isso.conf.section("rss")
+        if not conf.get('base'):
+            raise NotFound
+
         args = {
             'uri': uri,
             'order_by': 'id',
             'asc': 0,
-            'limit': 100
+            'limit': conf.getint('limit')
         }
         try:
             args['limit'] = max(int(request.args.get('limit')), args['limit'])
@@ -867,7 +871,7 @@ class API(object):
         except ValueError:
             return BadRequest("limit should be integer")
         comments = self.comments.fetch(**args)
-        base = self.conf.get('host').split()[0]
+        base = conf.get('base')
         hostname = urlparse(base).netloc
 
         # Let's build an Atom feed.

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -950,7 +950,16 @@ class API(object):
         ET.ElementTree(feed).write(output,
                                    encoding='utf-8',
                                    xml_declaration=True)
-        return XML(output.getvalue(), 200)
+        response = XML(output.getvalue(), 200)
+
+        # Add an etag/last-modified value for caching purpose
+        if comment0 is None:
+            response.set_etag('empty')
+            response.last_modified = 0
+        else:
+            response.set_etag('{tid}-{id}'.format(**comment0))
+            response.last_modified = comment0['modified'] or comment0['created']
+        return response.make_conditional(request)
 
     def preview(self, environment, request):
         data = request.get_json()

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -925,7 +925,7 @@ class API(object):
             content = ET.SubElement(entry, 'content', {
                 'type': 'html',
             })
-            content.text = comment['text']
+            content.text = self.isso.render(comment['text'])
 
             if comment['parent']:
                 ET.SubElement(entry, 'thr:in-reply-to', {

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -180,3 +180,15 @@ salt = Eech7co8Ohloopo9Ol6baimi
 # strengthening. Arguments have to be in that order, but can be reduced to
 # pbkdf2:4096 for example to override the iterations only.
 algorithm = pbkdf2
+
+
+[rss]
+# Provide an Atom feed for each comment thread for users to subscribe to.
+
+# The base URL of pages is needed to build the Atom feed. By appending
+# the URI, we should get the complete URL to use to access the page
+# with the comments. When empty, Atom feeds are disabled.
+base =
+
+# Limit the number of elements to return for each thread.
+limit = 100


### PR DESCRIPTION
We need absolute URL at some places. We assume the first host
configured is the base of the URI we have.

Fix #81.

This is mostly a "RFC". Notably, tests are missing.