### PR TITLE
embed: fix feed link creation on older browsers

### DIFF
--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -31,7 +31,7 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
             var feedLink = $.new('a', i18n.translate('atom-feed'));
             var feedLinkWrapper = $.new('span.isso-feedlink');
             feedLink.href = api.feed($("#isso-thread").getAttribute("data-isso-id"));
-            feedLinkWrapper.append(feedLink);
+            feedLinkWrapper.appendChild(feedLink);
             $("#isso-thread").append(feedLinkWrapper);
         }
         $("#isso-thread").append($.new('h4'));


### PR DESCRIPTION
When a browser doesn't support DOM manipulation convenience methods,
the addition of the feed link was triggering an error because elements
created by `$.new()` are regular elements, not elements from our own
mini-DOM implementation. Therefore, the `append()` method may be
absent. Use `appendChild()` instead.