### PR TITLE
i18n: fix zh_CN/TW translate of 'postbox-preview'

### DIFF
--- a/isso/js/app/i18n/zh_CN.js
+++ b/isso/js/app/i18n/zh_CN.js
@@ -3,7 +3,7 @@ define({
     "postbox-author": "名字 (可选)",
     "postbox-email": "E-mail (可选)",
     "postbox-website": "网站 (可选)",
-    "postbox-preview": "预习",
+    "postbox-preview": "预览",
     "postbox-edit": "编辑",
     "postbox-submit": "提交",
 

--- a/isso/js/app/i18n/zh_TW.js
+++ b/isso/js/app/i18n/zh_TW.js
@@ -3,7 +3,7 @@ define({
     "postbox-author": "名稱 (非必填)",
     "postbox-email": "電子信箱 (非必填)",
     "postbox-website": "個人網站 (非必填)",
-    "postbox-preview": "預習",
+    "postbox-preview": "預覽",
     "postbox-edit": "編輯",
     "postbox-submit": "送出",
 


### PR DESCRIPTION
preview should be translated into "预览" in this occation.

"预习" means "prepare lessons before class" in Chinese.