### PR TITLE
Substituting scss command in Makefile by node-sass + adding comment with instructions on how to install Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# INSTALLATION: pip install sphinx && npm install --global node-sass
+
 ISSO_JS_SRC := $(shell find isso/js/app -type f) \
 	       $(shell ls isso/js/*.js | grep -vE "(min|dev)") \
 	       isso/js/lib/requirejs-jade/jade.js
@@ -53,7 +55,7 @@ man: $(DOCS_RST_SRC)
 	mv man/isso.conf.5 man/man5/isso.conf.5
 
 ${DOCS_CSS_DST}: $(DOCS_CSS_SRC) $(DOCS_CSS_DEP)
-	scss --no-cache $(DOCS_CSS_SRC) $@
+	node-sass --no-cache $(DOCS_CSS_SRC) $@
 
 ${DOCS_HTML_DST}: $(DOCS_RST_SRC) $(DOCS_CSS_DST)
 	sphinx-build -b dirhtml docs/ $@


### PR DESCRIPTION
The `scss` command has been deprecated, now the `node-sass` command must be used directly.