### PR TITLE
feed: remove trailing / from base URL

### DIFF
--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -887,7 +887,7 @@ class API(object):
         except ValueError:
             return BadRequest("limit should be integer")
         comments = self.comments.fetch(**args)
-        base = conf.get('base')
+        base = conf.get('base').rstrip('/')
         hostname = urlparse(base).netloc
 
         # Let's build an Atom feed.


### PR DESCRIPTION
This way, one can use "/" as base URL. This is only valid if we are
sure that URI should always have a leading "/". Is that the case?

Fix #437.