### PR TITLE
Notify syscall 180709

### DIFF
--- a/README-notify-syscall.md
+++ b/README-notify-syscall.md
@@ -1,0 +1,106 @@
+
+# Send Notifications by arbitrary program via python systemcall
+
+The [*isso*] repository was forked by [github user craigphicks](https://github.com/craigphicks). A branch `notify-syscall-180709` was created.  The branch is described herein.
+
+# Motivation
+
+## Security
+
+When *isso* uses the *SMTP* notification backend, it also sends the username and password.  The are various perspectives from which this could be problematic.
+
+- **Password in clear:**  In the worst case TLS (Transport Layer Security) is not established before passing the password and so the password is transmitted in the clear.
+
+- **Key better than password:**  Even with TLS, the password is still in the clear at either end.  While this is usualloy OK, security can be improved by using a key which can be periodically refreshed.  The point of the key is that is that it is only authorizes a narrow range of actions. Especially, it does not allow loggin in as mail account owner, which could be very damaging.
+
+## Dependence on Python SMTP implementation
+
+*Isso* is tied to the Python SMTP implementation.  Even if SMTP is the desired protocol, the may be other software besides the Python SMTP implementation which gives a better result, e.g. in terms of enabling TLS or working with tokens.
+
+Some examples of alternate software are the multitude of generic sendmail programs, e.g. *sendmail, postfix, exim, nullmailer*, all of which all share the [linux sendmail application interface as a standard](http://refspecs.linux-foundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/baselib-sendmail-1.html).
+
+Also there utilities such as *curl* and *swaks* which are very flexible with many options. In case something is not working it is almost always possible to work through it with these programs (or change to another program).  Although they are not designed for production use, they are sufficient on the usage scale expected by a typical *isso* installation.
+
+# Solution
+
+## Outline
+
+The *isso* administrator specifies the program and it's arguments in the *isso* configuration file.  When a comment notification event occurs the specified program and arguments are executed via a system call.  The message is passed to the standard input of that program.
+
+## Administrator interface
+
+Add `syscall` to the list of notify backends:
+
+```
+[general]
+...
+notify = stdout, syscall
+...
+```
+
+Create a section `[syscall]` and therein specify the program and its arguments.  The following example shows `curl` being used to transmit an email request through a (free) Mailgun account:  
+
+```
+[syscall]
+nargs=8
+0 = /usr/bin/curl
+1 = --trace-ascii, /tmp/mg1.log
+2 = --user, api:<key>
+3 = https://api.mailgun.net/v3/<domain>/messages
+4 = -F, to=user@gmail.com
+5 = -F, from=isso@example.com
+6 = -F, subject=isso notify
+7 = -F, text=<-
+```
+
+The arguments are divided up into multiple lists only for convenience.  When more than one argument is used placed the same line, they must be saperated by a comma.  Whitespaces within an argument are preserved, but whitespaces around an argument are removed.
+
+The argument lines must by numbered in order from zero (0).
+
+`nargs` must be set to the number of argument lines, which is the maximum line number plus one.
+
+The last part of the last `curl` argument:  `<-' , is a curl specific instruction to accept data from standard input.  Because the message body is variable it must be transmitted via standard input to the process.  So any program used must be configured (or hard coded) to accept standard input.
+
+Be aware that protocol issues depend on the called program and the site receiving the data. It is not handled by the *isso* code.  For example, although the above example appears to transact via HTTPS, there is some possibilty it might downgrading to HTTP after authentication for the message transaction part.  The log file is still under interpretation.
+
+**Read the current limitations section at the end of this document.**
+
+
+## Implementation
+
+The *notify-syscall-180708* branch adds a new module `Syscall` in the `isso/ext/notifications.py` file.
+
+It formats the mail message body in the same way as the existing `SMTP` module, but without the SMTP header and *quopri* / *base64* encoding.
+
+The command and arguments as specified in the configuration are supplied as a list which is the first parameter of `subprocess.run`.
+
+The message body is encoded to binary and passed as standard intput to the invoked process.
+
+When complete, `subprocess.run` returns an object with members `returncode`, `stdout`, and 'stderr'.  All are logged via the global logger (usally to `/var/log/isso.log`).
+
+*Isso* expects that success is indicated by a `returncode` value of zero, and anything else is error.  However, an error does not result in an *isso* program error.  The only difference in *isso* program behavior is that for a non-zero result *isso* will log via
+
+    logger.error(....)
+
+and for a zero result via
+
+    logger.info(....)
+
+# Other changes
+
+The notification backend `Stdout` module was rewritten to fix a bug caused by trying to log a bloom filter as text.  Also, the relation between function names, log content, and events was cleaned up.
+
+# IMPORTANT: Current Limitations
+
+## Administration interface
+
+1. Currently the arguments specified in the cofig file cannot contain a comma. This limitation needs to be fixed. 
+2. For many choices of programs the mail subject is only configuarable as a program argument. However the subject is usually variable.  Currently there is no way to add variability to a subject line specified in the configuation file.  A template solution (e.g. `%SUBJECT%` in the argument) could be used to solve this problem.  
+
+
+## Implementation
+
+3. `subprocess.run` might not be available in *Python2*. It is available in *Python3*.  In the case of Python2, *syscall* should not be enabled ion the configuation file, if it even compiles. 
+
+
+

--- a/README-notify-syscall.md
+++ b/README-notify-syscall.md
@@ -53,7 +53,7 @@ call = /usr/bin/curl
  -F
  from=isso@pindertek.com
  -F
- subject=isso %SUBJECT%
+ subject=isso {{SUBJECT}}
  -F
  text=<-
 ```
@@ -62,10 +62,10 @@ The key `call` appears on the first line followed by equal.  The value is split 
 Often in a shell command line quotation mark must be used to prevent a parser from interpreting spaces as being argument delimiters.  E.g., for the subject 
 
 ```
- subject=isso %SUBJECT%
+ subject=isso {{SUBJECT}}
 ```
 
-a bash script would require quotes placed like `"subject=isso %SUBJECT%"` or  'subject="isso %SUBJECT%" to keep the argument together.  The shell would interpret the quotes for their synactic meaning, and then remove them before passing each argument phrase to the program as, e.g. *argv[11]* or equivalent.
+a bash script would require quotes placed like `"subject=isso {{SUBJECT}}"` or  `subject="isso {{SUBJECT}}` to keep the argument together.  The shell would interpret the quotes for their synactic meaning, and then remove them before passing each argument phrase to the program as, e.g. *argv[11]* or equivalent.
 
 However, for the *isso* configuatation `call` value above, quotes are not required because the grouping is done by lines.  **In fact quotes for the purpose of syntactic grouping must NOT be used.**   The quotes will not be removed before passing to the program, and the input will likely be invalid. Quotes can still be used as part of the content of any argument, as required. 
 

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -72,7 +72,7 @@ from isso.wsgi import origin, urlsplit
 from isso.utils import http, JSONRequest, html, hash
 from isso.views import comments
 
-from isso.ext.notifications import Stdout, SMTP
+from isso.ext.notifications import Stdout, SMTP, Syscall
 
 logging.getLogger('werkzeug').setLevel(logging.WARN)
 logging.basicConfig(
@@ -101,6 +101,8 @@ class Isso(object):
                 subscribers.append(Stdout(None))
             elif backend in ("smtp", "SMTP"):
                 subscribers.append(SMTP(self))
+            elif backend == ("syssendmail"):
+                subscribers.append(Syscall(self))
             else:
                 logger.warn("unknown notification backend '%s'", backend)
 

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -101,7 +101,7 @@ class Isso(object):
                 subscribers.append(Stdout(None))
             elif backend in ("smtp", "SMTP"):
                 subscribers.append(SMTP(self))
-            elif backend == ("syssendmail"):
+            elif backend == ("syscall"):
                 subscribers.append(Syscall(self))
             else:
                 logger.warn("unknown notification backend '%s'", backend)

--- a/isso/config.py
+++ b/isso/config.py
@@ -135,6 +135,8 @@ def load(default, user=None):
         parser.read(user)
 
     for item in setify(parser).difference(a):
+        if item[0]=="syscall":
+            continue
         logger.warn("no such option: [%s] %s", *item)
         if item in (("server", "host"), ("server", "port")):
             logger.warn("use `listen = http://$host:$port` instead")

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -259,35 +259,21 @@ class Syscall(object):
         yield "comments.new:after-save", self._new_comment_after_save
         yield "comments.edit", self._edit_comment
 
-            
     def _new_comment_after_save(self, thread, comment):
         key=self.isso.sign(comment["id"])
         msgbody=_format(thread,comment,self.general_host,key)
-
-        # cmdlist=[]
-        # nargs=self.conf.getint("nargs")
-        # for i in range(0, nargs):
-        #     for s in self.conf.getlist(str(i)):
-        #         cmdlist.append(s)
-
         subject = "..." + thread['uri'][-15:] + " :: " + comment['text'][:15] + "..."
         cmdlist = [ a.replace('{{SUBJECT}}',subject,1) for a in self.conf.getiter('call') ]
-
         logger.info(cmdlist);
-
-        import pdb; pdb.set_trace() # iwozere
-
         p=subprocess.run(cmdlist,
                          input=str(msgbody).encode(),
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
-
         s = "Syscall: return code " + str(p.returncode) + "\n" \
         + "stdout:\n" \
         + str(p.stdout) + "\n" \
         + "stderr:\n" \
         + str(p.stderr) + "\n"
-
         if p.returncode != 0:
             logger.error(s)
         else:

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -53,8 +53,7 @@ def _format(thread, comment, general_host, key):
              (local("origin") + thread["uri"] + "#isso-%i" % comment["id"]))
     rv.write("\n")
 
-    uri = general_host + "/id/%i" % comment["id"]
-#    key = self.isso.sign(comment["id"])
+    uri = local.host + "/id/%i" % comment["id"]
 
     rv.write("---\n")
     rv.write("Delete comment: %s\n" % (uri + "/delete/" + key))
@@ -149,7 +148,7 @@ class SMTP(object):
                  (local("origin") + thread["uri"] + "#isso-%i" % comment["id"]))
         rv.write("\n")
 
-        uri = self.general_host + "/id/%i" % comment["id"]
+        uri = local.host + "/id/%i" % comment["id"]
         key = self.isso.sign(comment["id"])
 
         rv.write("---\n")

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -247,7 +247,7 @@ class Syscall(object):
 
     def __init__(self, isso):
         self.isso = isso
-        self.conf = isso.conf.section("syssendmail")
+        self.conf = isso.conf.section("syscall")
         gh = isso.conf.get("general", "host")
         if type(gh) == str:
             self.general_host = gh

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -264,13 +264,18 @@ class Syscall(object):
         key=self.isso.sign(comment["id"])
         msgbody=_format(thread,comment,self.general_host,key)
 
-        cmdlist=[]
-        nargs=self.conf.getint("nargs")
-        for i in range(0, nargs):
-            for s in self.conf.getlist(str(i)):
-                cmdlist.append(s)
+        # cmdlist=[]
+        # nargs=self.conf.getint("nargs")
+        # for i in range(0, nargs):
+        #     for s in self.conf.getlist(str(i)):
+        #         cmdlist.append(s)
 
-#        import pdb; pdb.set_trace() # iwozere
+        subject = "..." + thread['uri'][-15:] + " :: " + comment['text'][:15] + "..."
+        cmdlist = [ a.replace('{{SUBJECT}}',subject,1) for a in self.conf.getiter('call') ]
+
+        logger.info(cmdlist);
+
+        import pdb; pdb.set_trace() # iwozere
 
         p=subprocess.run(cmdlist,
                          input=str(msgbody).encode(),
@@ -282,7 +287,7 @@ class Syscall(object):
         + str(p.stdout) + "\n" \
         + "stderr:\n" \
         + str(p.stderr) + "\n"
-        
+
         if p.returncode != 0:
             logger.error(s)
         else:


### PR DESCRIPTION
# Send Notifications by arbitrary program via python systemcall

The [*isso*] repository was forked by [github user craigphicks](https://github.com/craigphicks). A branch `notify-syscall-180709` was created.  The branch is described herein.

The main uncertainly I have as author is the use of `subprocess.run`  which appeared in Python3.5.  Which versions of Python must be supported?  Must Python 2 be supported?  (See *Limitations* at the end of this document).

This comment is copied from the file *./README-notify-syscall-180709* in hte main directory.

# Motivation

## Security

When *isso* uses the *SMTP* notification backend, it also sends the username and password.  The are various perspectives from which this could be problematic.

- **Password in clear:**  In the worst case TLS (Transport Layer Security) is not established before passing the password and so the password is transmitted in the clear.

- **Key better than password:**  Even with TLS, the password is still in the clear at either end.  While this is usually OK, security can be improved by using a key which can be periodically refreshed.  The point of the key is that is that it is only authorizes a narrow range of actions. Especially, it does not allow logging in as mail account owner, which could be very damaging.

## Dependence on Python SMTP implementation

*Isso* is tied to the Python SMTP implementation.  Even if SMTP is the desired protocol, the may be other software besides the Python SMTP implementation which gives a better result, e.g. in terms of enabling TLS or working with tokens.

Some examples of alternate software are the multitude of generic sendmail programs, e.g. *sendmail, postfix, exim, nullmailer*, all of which all share the [linux sendmail application interface as a standard](http://refspecs.linux-foundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/baselib-sendmail-1.html).

Also there utilities such as *curl* and *swaks* which are very flexible with many options. In case something is not working it is almost always possible to work through it with these programs (or change to another program).  Although they are not designed for production use, they are sufficient on the usage scale expected by a typical *isso* installation.

# Solution

## Outline

The *isso* administrator specifies the program and it's arguments in the *isso* configuration file.  When a comment notification event occurs the specified program and arguments are executed via a system call.  The message is passed to the standard input of that program.

## Administrator interface

Add `syscall` to the list of notify backends:

```
[general]
...
notify = stdout, syscall
...
```

Create a section `[syscall]` and therein specify the program and its arguments.  The following example shows `curl` being used to transmit an email request through a (free) Mailgun account:  

```
[syscall]
call = /usr/bin/curl
 --trace-ascii
 /tmp/mg1.log
 --user
 api:key-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 https://api.mailgun.net/v3/example.com/messages
 -F
 to=risu@gmail.com
 -F
 from=isso@pindertek.com
 -F
 subject=isso {{SUBJECT}}
 -F
 text=<-
```

The key `call` appears on the first line followed by equal.  The value is split between lines with exactly one argument per line.  Each successive value line must have an empty space at the beginning. 
Often in a shell command line quotation mark must be used to prevent a parser from interpreting spaces as being argument delimiters.  E.g., for the subject 

```
 subject=isso {{SUBJECT}}
```

a bash script would require quotes placed like `"subject=isso {{SUBJECT}}"` or  `subject="isso {{SUBJECT}}"` to keep the argument together.  The shell would interpret the quotes for their syntactic meaning, and then remove them before passing each argument phrase to the program as, e.g. *argv[11]* or equivalent.

However, for the *isso* configuration `call` value above, quotes are not required because the grouping is done by lines.  **In fact quotes for the purpose of syntactic grouping must NOT be used.**   The quotes will not be removed before passing to the program, and the input will likely be invalid. Quotes can still be used as part of the content of any argument, as required. 

Some (but not all) scenarios require the mail subject to be specified as part of the arguments, and not in the standard input data.  The above `curl` example shows such a case.  In order to enable variable subject line content a template parameter `%SUBJECT%` is provided.  The *isso* software will render this template %SUBJECT% as the fixed formula:

> ...<last 15 characters of blog uri> ::: <first 15 characters of comment>...

The last part of the last `curl` argument:  `<-' , is a curl specific instruction to accept data from standard input.  Because the message body is variable it must be transmitted via standard input to the process.  So any program used must be configured (or already be hard coded) to accept standard input.

Be aware that protocol issues depend on the called program and the site receiving the data. It is not handled by the *isso* code.  For example, although the above example appears to transact via HTTPS, there is some possibility it might downgrading to HTTP after authentication for the message transaction part.  (The log file is still under interpretation.)

**Read the current limitations section at the end of this document.**


## Implementation

The *notify-syscall-180708* branch adds a new module `Syscall` in the `isso/ext/notifications.py` file.

It formats the mail message body in the same way as the existing `SMTP` module, but without the SMTP header and *quopri* / *base64* encoding.

The command and arguments as specified in the configuration are supplied as a list which is the first parameter of `subprocess.run`.

The message body is encoded to binary and passed as standard input to the invoked process.

When complete, `subprocess.run` returns an object with members `returncode`, `stdout`, and 'stderr'.  All are logged via the global logger (usually to `/var/log/isso.log`).

*Isso* expects that success is indicated by a `returncode` value of zero, and anything else is error.  However, an error does not result in an *isso* program error.  The only difference in *isso* program behavior is that for a non-zero result *isso* will log via

    logger.error(....)

and for a zero result via

    logger.info(....)

# Other changes

The notification backend `Stdout` module was rewritten to fix a bug caused by trying to log a bloom filter as text.  Also, the relation between function names, log content, and events was cleaned up.

# IMPORTANT: Current Limitations

## Implementation

1. `subprocess.run` is not available before *Python 3.5*.  Certainly not in *Python2*. In environments where the code will not run it should not be enabled in the configuration file, (if it even compiles). 
