### PR TITLE
Allow subdirectory server configuration, e.g. https://example.com/isso

### DIFF
--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -1,8 +1,8 @@
 <html>
 <head>
   <title>Isso admin</title>
-  <link type="text/css" href="/css/isso.css" rel="stylesheet">
-  <link type="text/css" href="/css/admin.css" rel="stylesheet">
+  <link type="text/css" href="{{isso_host_script}}/css/isso.css" rel="stylesheet">
+  <link type="text/css" href="{{isso_host_script}}/css/admin.css" rel="stylesheet">
 </head>
 <body>
 <script type="text/javascript">
@@ -32,16 +32,16 @@ function fade(element) {
         op -= op * 0.1;
     }, 10);
 }
-function moderate(com_id, hash, action) {
+function moderate(com_id, hash, action, isso_host_script) {
   ajax({method: "POST",
-        url: "/id/" + com_id + "/" + action + "/" + hash,
+        url: "" + isso_host_script + "/id/" + com_id + "/" + action + "/" + hash,
         success: function(){
             fade(document.getElementById("isso-" + com_id));
         }});
 }
-function edit(com_id, hash, author, email, website, comment) {
+function edit(com_id, hash, author, email, website, comment, isso_host_script) {
   ajax({method: "POST",
-        url: "/id/" + com_id + "/edit/" + hash,
+        url: "" + isso_host_script + "/id/" + com_id + "/edit/" + hash,
         data: JSON.stringify({text: comment,
                               author: author,
                               email: email,
@@ -53,11 +53,11 @@ function edit(com_id, hash, author, email, website, comment) {
           console.log("Error: ", ret); // TODO flash msg/notif
         }});
 }
-function validate_com(com_id, hash) {
-    moderate(com_id, hash, "activate");
+function validate_com(com_id, hash, isso_host_script) {
+    moderate(com_id, hash, "activate", isso_host_script);
 }
-function delete_com(com_id, hash) {
-    moderate(com_id, hash, "delete");
+function delete_com(com_id, hash, isso_host_script) {
+    moderate(com_id, hash, "delete", isso_host_script);
 }
 function unset_editable(elt_id) {
     var elt = document.getElementById(elt_id);
@@ -97,19 +97,19 @@ function stop_edit(com_id) {
     document.getElementById('stop-edit-btn-' + com_id).classList.toggle('hidden');
     document.getElementById('send-edit-btn-' + com_id).classList.toggle('hidden');
 }
-function send_edit(com_id, hash) {
+function send_edit(com_id, hash, isso_host_script) {
     var author = document.getElementById('isso-author-' + com_id).textContent;
     var email = document.getElementById('isso-email-' + com_id).textContent;
     var website = document.getElementById('isso-website-' + com_id).textContent;
     var comment = document.getElementById('isso-text-' + com_id).textContent;
-    edit(com_id, hash, author, email, website, comment);
+    edit(com_id, hash, author, email, website, comment, isso_host_script);
     stop_edit(com_id);
 }
 </script>
   <div class="wrapper">
     <div class="header">
       <header>
-        <img class="logo" src="/img/isso.svg" alt="Wynaut by @veekun"/>
+        <img class="logo" src="{{isso_host_script}}/img/isso.svg" alt="Wynaut by @veekun"/>
         <div class="title">
           <a href="./">
             <h1>Isso</h1>
@@ -232,16 +232,16 @@ function send_edit(com_id, hash) {
         <span class='spacer'></span>
         <a id="edit-btn-{{comment.id}}" class="edit" onClick="javascript:start_edit({{comment.id}})">Edit</a>
         <a id="stop-edit-btn-{{comment.id}}" class="hidden edit" onClick="javascript:stop_edit({{comment.id}})">Cancel</a>
-        <a id="send-edit-btn-{{comment.id}}" class="hidden edit" onClick="javascript:send_edit({{comment.id}}, '{{comment.hash}}')">Send</a>
+        <a id="send-edit-btn-{{comment.id}}" class="hidden edit" onClick="javascript:send_edit({{comment.id}}, '{{comment.hash}}','{{isso_host_script}}')">Send</a>
         {% if comment.mode != 4 %}
           <a class="delete"
-             onClick="javascript:delete_com({{comment.id}}, '{{comment.hash}}')">
+             onClick="javascript:delete_com({{comment.id}}, '{{comment.hash}}', '{{isso_host_script}}')">
             Delete
           </a>
         {% endif %}
         {% if comment.mode == 2 %}
           <a class='validate'
-             onClick="javascript:validate_com({{comment.id}}, '{{comment.hash}}')">Validate</a>
+             onClick="javascript:validate_com({{comment.id}}, '{{comment.hash}}', '{{isso_host_script}}')">Validate</a>
         {% endif %}
       </div>
     </div>

--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -34,14 +34,14 @@ function fade(element) {
 }
 function moderate(com_id, hash, action, isso_host_script) {
   ajax({method: "POST",
-        url: "" + isso_host_script + "/id/" + com_id + "/" + action + "/" + hash,
+        url: isso_host_script + "/id/" + com_id + "/" + action + "/" + hash,
         success: function(){
             fade(document.getElementById("isso-" + com_id));
         }});
 }
 function edit(com_id, hash, author, email, website, comment, isso_host_script) {
   ajax({method: "POST",
-        url: "" + isso_host_script + "/id/" + com_id + "/edit/" + hash,
+        url: isso_host_script + "/id/" + com_id + "/edit/" + hash,
         data: JSON.stringify({text: comment,
                               author: author,
                               email: email,

--- a/isso/templates/login.html
+++ b/isso/templates/login.html
@@ -1,14 +1,14 @@
 <html>
 <head>
   <title>Isso admin</title>
-  <link type="text/css" href="/css/isso.css" rel="stylesheet">
-  <link type="text/css" href="/css/admin.css" rel="stylesheet">
+  <link type="text/css" href="{{isso_host_script}}/css/isso.css" rel="stylesheet">
+  <link type="text/css" href="{{isso_host_script}}/css/admin.css" rel="stylesheet">
 </head>
 <body>
   <div class="wrapper">
     <div class="header">
       <header>
-        <img class="logo" src="/img/isso.svg" alt="Wynaut by @veekun"/>
+        <img class="logo" src="{{isso_host_script}}/img/isso.svg" alt="Wynaut by @veekun"/>
         <div class="title">
           <a href="./">
             <h1>Isso</h1>
@@ -20,7 +20,7 @@
     <main>
       <div id="login">
         Administration secured by password:
-        <form method="POST" action="/login">
+        <form method="POST" action="{{isso_host_script}}/login">
           <input type="password" name="password" />
         </form>
       </div>

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -1001,7 +1001,7 @@ class API(object):
             response = redirect(re.sub(
                 r'/login$',
                 '/admin',
-                get_current_url(env, strip_querystring=True) #iwozere
+                get_current_url(env, strip_querystring=True)
             ))
             cookie = functools.partial(dump_cookie,
                                        value=self.isso.sign({"logged": True}),

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -1001,7 +1001,7 @@ class API(object):
             response = redirect(re.sub(
                 r'/login$',
                 '/admin',
-                get_current_url(env, strip_querystring=True)
+                get_current_url(env, strip_querystring=True) #iwozere
             ))
             cookie = functools.partial(dump_cookie,
                                        value=self.isso.sign({"logged": True}),
@@ -1010,16 +1010,16 @@ class API(object):
             response.headers.add("X-Set-Cookie", cookie("isso-admin-session"))
             return response
         else:
-            return render_template('login.html')
+            return render_template('login.html', isso_host_script=local.host)
 
     def admin(self, env, req):
         try:
             data = self.isso.unsign(req.cookies.get('admin-session', ''),
                                     max_age=60 * 60 * 24)
         except BadSignature:
-            return render_template('login.html')
+            return render_template('login.html',isso_host_script=local.host)
         if not data or not data['logged']:
-            return render_template('login.html')
+            return render_template('login.html',isso_host_script=local.host)
         page_size = 100
         page = int(req.args.get('page', 0))
         order_by = req.args.get('order_by', None)
@@ -1039,4 +1039,5 @@ class API(object):
                                page=int(page), mode=int(mode),
                                conf=self.conf, max_page=max_page,
                                counts=comment_mode_count,
-                               order_by=order_by, asc=asc)
+                               order_by=order_by, asc=asc,
+                               isso_host_script=local.host)

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -994,7 +994,7 @@ class API(object):
             get_current_url(env, strip_querystring=True) + '/index.html'
         )
 
-    def login(self, env, req):
+    def login(self, env, req):        
         data = req.form
         password = self.isso.conf.get("general", "admin_password")
         if data['password'] and data['password'] == password:
@@ -1010,16 +1010,18 @@ class API(object):
             response.headers.add("X-Set-Cookie", cookie("isso-admin-session"))
             return response
         else:
-            return render_template('login.html', isso_host_script=local.host)
+            isso_host_script = self.isso.conf.get("server", "public-endpoint") or local.host
+            return render_template('login.html', isso_host_script=isso_host_script)
 
     def admin(self, env, req):
+        isso_host_script = self.isso.conf.get("server", "public-endpoint") or local.host
         try:
             data = self.isso.unsign(req.cookies.get('admin-session', ''),
                                     max_age=60 * 60 * 24)
         except BadSignature:
-            return render_template('login.html',isso_host_script=local.host)
+            return render_template('login.html',isso_host_script=isso_host_script)
         if not data or not data['logged']:
-            return render_template('login.html',isso_host_script=local.host)
+            return render_template('login.html',isso_host_script=isso_host_script)
         page_size = 100
         page = int(req.args.get('page', 0))
         order_by = req.args.get('order_by', None)
@@ -1040,4 +1042,4 @@ class API(object):
                                conf=self.conf, max_page=max_page,
                                counts=comment_mode_count,
                                order_by=order_by, asc=asc,
-                               isso_host_script=local.host)
+                               isso_host_script=isso_host_script)


### PR DESCRIPTION
# Allow sudirectory server configuration, , e.g. https://example.com/isso

## Description

When the isso root location was 

    https://example.com/isso

the administration pages did not work correctly.  The changes in this pull request fix that and allow proper working with or without a subdirectory.  E.g. both of these become valid configurations:

    https://example.com
    https://example.com/isso

The subdirectory case only requires the subdirectory to be passed as a parameter in the proxy call.  Here is an example *nginx* setup:

    location /isso {
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Script-Name /isso;      // <---- critical for subdirectory config
        proxy_set_header Host $host;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_pass http://localhost:1234;
    }
 
If the line `proxy_set_header X-Script-Name /isso;` is omitted, communication with *isso* will fail.

## Testing 

Given the blog address "https:\example.com", *isso* was tested using the following sites:

    https://example.com/isso
    https://another.com
    https://another.com/isso

## Other bugs found, not fixed yet

The *active* and *delete* URLs sent by the *isso* mail notification system were found to fail under the following conditions, with the follow symptoms:

1. *Condition:* Blog and Isso servers differ.  E.g.  `https://example.com/` and `https://another.com/`.  
    *Symptom:* The *active/delete* URLs use the blog server instead of the isso server.
2. *Condition:* Isso is cofigured as a subdirectory, e.g. `https://example.com/isso`.  
    *Symptom:* The `isso` part is not included in the URL.
3. *Condition:* Both 1 and 2 together.
    *Symptom:* Both

I will try to address these mail bugs later. 
