### PR TITLE
fix mail acitvation/delete links, c.f. issue #449

### DIFF
--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -115,7 +115,7 @@ class SMTP(object):
                  (local("origin") + thread["uri"] + "#isso-%i" % comment["id"]))
         rv.write("\n")
 
-        uri = self.general_host + "/id/%i" % comment["id"]
+        uri = local.host + "/id/%i" % comment["id"]
         key = self.isso.sign(comment["id"])
 
         rv.write("---\n")


### PR DESCRIPTION
As mentioned by @schiessle in [issue 449](https://github.com/posativ/isso/issues/449) mail activation and delete links were not correct for case of subdirectory configuration.  (Also true for case of different server).

This fix was tested in these cases:

```
https://blogsite.com/isso
https://anothersite.com
https://anothersite.com/isso
```

