### PR TITLE
template: admin: add id `isso-root` to comments wrapper

### DIFF
--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -172,7 +172,7 @@ function send_edit(com_id, hash) {
           {% endfor %}
         </div>
     </div>
-    <main>
+    <div id="isso-root">
     {% set thread_id = "no_id" %}
     {% for comment in comments %}
       {% if order_by == "tid" %}
@@ -247,7 +247,7 @@ function send_edit(com_id, hash) {
     </div>
 </div>
     {% endfor %}
-    </main>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
make use of style in isso.css, the admin page layout would be more neat

after:
![image](https://user-images.githubusercontent.com/13914967/43352217-e1b3b018-9252-11e8-8af6-b165f29c0b82.png)

before:
![image](https://user-images.githubusercontent.com/13914967/43352240-310505f4-9253-11e8-9707-077e8979c3fb.png)
