### PR TITLE
add  "postbox-notification"

### DIFF
--- a/isso/js/app/i18n/ru.js
+++ b/isso/js/app/i18n/ru.js
@@ -6,6 +6,7 @@ define({
     "postbox-preview": "Предпросмотр",
     "postbox-edit": "Правка",
     "postbox-submit": "Отправить",
+    "postbox-notification": "Подписаться на уведомление об ответах",
     "num-comments": "{{ n }} комментарий\n{{ n }} комментария\n{{ n }} комментариев",
     "no-comments": "Пока нет комментариев",
     "comment-reply": "Ответить",


### PR DESCRIPTION
By the way, what happens if there is no translation for some entry? Isso uses English? For example, there is no Russian translation for "atom-feed", but I think it is OK to display "Atom feed" for Russian users.