### PR TITLE
Make password form focused on page load

### DIFF
--- a/isso/templates/login.html
+++ b/isso/templates/login.html
@@ -21,7 +21,7 @@
       <div id="login">
         Administration secured by password:
         <form method="POST" action="{{isso_host_script}}/login">
-          <input type="password" name="password" />
+          <input type="password" name="password" autofocus />
         </form>
       </div>
     </main>


### PR DESCRIPTION
No need to click on the input form to type in the password, it is active by default