### PR TITLE
i18n: fix zh_CN/TW 'optional' in postbox placeholder

### DIFF
--- a/isso/js/app/i18n/zh_CN.js
+++ b/isso/js/app/i18n/zh_CN.js
@@ -1,8 +1,8 @@
 define({
-    "postbox-text": "在此输入评论（最少 3 个字符）",
-    "postbox-author": "名字（可选）",
-    "postbox-email": "电子邮箱（可选）",
-    "postbox-website": "网站（可选）",
+    "postbox-text": "在此输入评论 (最少 3 个字符)",
+    "postbox-author": "名字 (可选)",
+    "postbox-email": "电子邮箱 (可选)",
+    "postbox-website": "网站 (可选)",
     "postbox-preview": "预览",
     "postbox-edit": "编辑",
     "postbox-submit": "提交",

--- a/isso/js/app/i18n/zh_TW.js
+++ b/isso/js/app/i18n/zh_TW.js
@@ -1,8 +1,8 @@
 define({
-    "postbox-text": "在此輸入留言（至少 3 個字元）",
-    "postbox-author": "名稱（非必填）",
-    "postbox-email": "電子信箱（非必填）",
-    "postbox-website": "個人網站（非必填）",
+    "postbox-text": "在此輸入留言 (至少 3 個字元)",
+    "postbox-author": "名稱 (非必填)",
+    "postbox-email": "電子信箱 (非必填)",
+    "postbox-website": "個人網站 (非必填)",
     "postbox-preview": "預覽",
     "postbox-edit": "編輯",
     "postbox-submit": "送出",


### PR DESCRIPTION
I haven't relaized that Isso hardcode a space and a pair of ASCII barckets for that `(optional)` substring detection (see below) before I submit PR #469 , which makes postbox name and email always display as optional.

https://github.com/posativ/isso/blob/9c57ac22e5390773089f58c048e9c6ad7e6535b8/isso/js/app/isso.js#L54-L64

Apologize for that mistake, sorry ...

This PR also changes EOL sequence of `zh_TW.js` from CRLF to LF, as all other files do.