### PR TITLE
Use AF_INET if AF_UNIX isn't available (i.e. Windows)

### DIFF
--- a/isso/wsgi.py
+++ b/isso/wsgi.py
@@ -200,7 +200,11 @@ class SocketHTTPServer(HTTPServer, ThreadingMixIn):
     multiprocess = False
 
     allow_reuse_address = 1
-    address_family = socket.AF_UNIX
+
+    try:
+        address_family = socket.AF_UNIX
+    except AttributeError:
+        address_family = socket.AF_INET
 
     request_queue_size = 128
 


### PR DESCRIPTION
Just something that I never got around to pushing back here.