### PR TITLE
use author names in gravatars

### DIFF
--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -809,7 +809,7 @@ class API(object):
         if not self.conf.getboolean('gravatar'):
             return item
 
-        email = item['email'] or ""
+        email = item['email'] or item['author'] or ''
         email_md5_hash = md5(email)
 
         gravatar_url = self.conf.get('gravatar-url')
@@ -1066,7 +1066,7 @@ class API(object):
             get_current_url(env, strip_querystring=True) + '/index.html'
         )
 
-    def login(self, env, req):        
+    def login(self, env, req):
         data = req.form
         password = self.isso.conf.get("general", "admin_password")
         if data['password'] and data['password'] == password:


### PR DESCRIPTION
We're using gravatars. Most of our users do not provide e-mails. With the current implementation, different people look the same (they all use default icon) and as such, the avatars aren't very useful.

The proposed change makes gravatars fall back to authors' nicknames when they didn't provide an e-mail. That way, if someone leaves multiple comments under the same nickname, they'll have the same gravatar, but they'll still be different from other users who use different nicknames.