### PR TITLE
embed: do not jump to unrelated anchor on load

### DIFF
--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -71,7 +71,8 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
                     isso.insert_loader(rv, lastcreated);
                 }
 
-                if (window.location.hash.length > 0) {
+                if (window.location.hash.length > 0 &&
+                    window.location.hash.match("^#isso-[0-9]+$")) {
                     $(window.location.hash).scrollIntoView();
                 }
             },


### PR DESCRIPTION
When loading, Isso scrolls to the current document hash. This makes
sense when the document hash references a comment, but this doesn't
for an unrelated anchor. Tell Isso to only scroll for a comment.