### PR TITLE
css: fix vertical alignment of notification checkbox

### DIFF
--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -178,6 +178,15 @@
     border: 1px solid rgba(0, 0, 0, 0.2);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
+.isso-postbox > .form-wrapper input[type=checkbox] {
+    vertical-align: middle;
+    position: relative;
+    bottom: 1px;
+    margin-left: 0;
+}
+.isso-postbox > .form-wrapper .notification-section {
+    padding-top: .3em;
+}
 #isso-thread .textarea:focus,
 #isso-thread input:focus {
     border-color: rgba(0, 0, 0, 0.8);

--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -185,6 +185,7 @@
     margin-left: 0;
 }
 .isso-postbox > .form-wrapper .notification-section {
+    font-size: 0.90em;
     padding-top: .3em;
 }
 #isso-thread .textarea:focus,


### PR DESCRIPTION
This is usually a pain to vertically align without additional markup.
The proposed solution happens to be the shortest solution I know of,
but it may be outdated.

The second commit is to reduce the size of the label. I have put it in another commit as it may not be approved. Feel free to drop it.