### PR TITLE
embed: fix feed link creation on older browsers

### DIFF
--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -37,7 +37,7 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
             var feedLink = $.new('a', i18n.translate('atom-feed'));
             var feedLinkWrapper = $.new('span.isso-feedlink');
             feedLink.href = api.feed(isso_thread.getAttribute("data-isso-id"));
-            feedLinkWrapper.append(feedLink);
+            feedLinkWrapper.appendChild(feedLink);
             isso_thread.append(feedLinkWrapper);
         }
         isso_thread.append(heading);


### PR DESCRIPTION
When a browser doesn't support DOM manipulation convenience methods,
the addition of the feed link was triggering an error because elements
created by `$.new()` are regular elements, not elements from our own
mini-DOM implementation. Therefore, the `append()` method may be
absent. Use `appendChild()` instead.

This was already pushed previously in #426 but it was inadvertently reverted in #452.