### PR TITLE
Don't open the admin page with a default password by default. Fixes #491

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for Isso
 0.11.2 (unreleased)
 -------------------
 
+- Don't enable admin interface with default password by default.
+  (Jelmer Vernooĳ, #491)
+
 0.11.1 (2018-11-03)
 -------------------
 

--- a/isso/templates/disabled.html
+++ b/isso/templates/disabled.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+  <title>Isso admin</title>
+  <link type="text/css" href="{{isso_host_script}}/css/isso.css" rel="stylesheet">
+  <link type="text/css" href="{{isso_host_script}}/css/admin.css" rel="stylesheet">
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header">
+      <header>
+        <img class="logo" src="{{isso_host_script}}/img/isso.svg" alt="Wynaut by @veekun"/>
+        <div class="title">
+          <a href="./">
+            <h1>Isso</h1>
+            <h2>Administration</h2>
+          </a>
+        </div>
+      </header>
+    </div>
+    <main>
+      <div id="disabled">
+        Administration is disabled on this instance of isso. Set enabled=true
+        in the admin section of your isso configuration to enable it.
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -1068,7 +1068,7 @@ class API(object):
 
     def login(self, env, req):
         data = req.form
-        password = self.isso.conf.get("general", "admin_password")
+        password = self.isso.conf.get("admin", "password")
         if data['password'] and data['password'] == password:
             response = redirect(re.sub(
                 r'/login$',
@@ -1087,6 +1087,9 @@ class API(object):
 
     def admin(self, env, req):
         isso_host_script = self.isso.conf.get("server", "public-endpoint") or local.host
+        if not self.isso.conf.getboolean("admin", "enabled"):
+            return render_template(
+                'disabled.html', isso_host_script=isso_host_script)
         try:
             data = self.isso.unsign(req.cookies.get('admin-session', ''),
                                     max_age=60 * 60 * 24)

--- a/share/isso-dev.conf
+++ b/share/isso-dev.conf
@@ -11,7 +11,10 @@ max-age = 15m
 notify = stdout
 reply-notifications = false
 log-file = /var/log/isso.log
-admin_password = strong_default_password_for_isso_admin
+
+[admin]
+enabled = true
+password = strong_default_password_for_isso_admin
 
 [moderation]
 enabled = false

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -59,9 +59,11 @@ gravatar = false
 # default url for gravatar. {} is where the hash will be placed
 gravatar-url = https://www.gravatar.com/avatar/{}?d=identicon
 
-# Admin access password
-admin_password = please_choose_a_strong_password
+[admin]
+enabled = false
 
+# Admin access password
+_password = please_choose_a_strong_password
 
 [moderation]
 # enable comment moderation queue. This option only affects new comments.


### PR DESCRIPTION
Don't open the admin page with a default password by default. Fixes #491
