### PR TITLE
Add a missing closing brace

### DIFF
--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -239,6 +239,7 @@
         #fff 10px,
         #fff 20px
     );
+}
 .isso-postbox > .form-wrapper > .notification-section {
     display: none;
     padding-bottom: 10px;


### PR DESCRIPTION
Gotta love IDE highlighting: one little brace was missing near the end of the CSS file. This means the last couple of definitions were ignored previously.