### PR TITLE
Add data-isso-reply-notifications to attributes

### DIFF
--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -13,6 +13,7 @@ preferably in the script tag which embeds the JS:
             data-isso-reply-to-self="false"
             data-isso-require-author="false"
             data-isso-require-email="false"
+            data-isso-reply-notifications="false"
             data-isso-max-comments-top="10"
             data-isso-max-comments-nested="5"
             data-isso-reveal-on-click="5"


### PR DESCRIPTION
There is a header describing `data-isso-reply-notifications` but it is not in the initial data attributes examples. I assume the initial list is meant to be exhaustive? I overlooked this setting on my initial read through the docs because it wasn't there, so I thought it would be helpful to add.