### PR TITLE
Fix notifications when hosting on pythonanywhere.com

### DIFF
--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -84,9 +84,11 @@ logger = logging.getLogger("isso")
 
 class Isso(object):
 
-    def __init__(self, conf):
+    def __init__(self, conf, **kwargs):
 
         self.conf = conf
+        for key, val in kwargs.items():
+            setattr(self, key, val)
         self.db = db.SQLite3(conf.get('general', 'dbpath'), conf)
         self.signer = URLSafeTimedSerializer(
             self.db.preferences.get("session-key"))
@@ -171,7 +173,12 @@ def make_app(conf=None, threading=True, multiprocessing=False, uwsgi=False):
         class App(Isso, uWSGIMixin):
             pass
 
-    isso = App(conf)
+    kwargs = {
+        "threading": threading,
+        "multiprocessing": multiprocessing,
+        "uwsgi": uwsgi,
+    }
+    isso = App(conf, **kwargs)
 
     # check HTTP server connection
     for host in conf.getiter("general", "host"):


### PR DESCRIPTION
Hey guys,
Not sure if this is the right thing to do here, but I thought I'd share what I did to get things working in case it is helpful. I was having trouble with the email notifications on my site hosted at pythonanywhere.com. At first I was having issues where the `uwsgi` module has no `spool` attribute. I saw on google that that's something that has to be put in at compile time and I assumed I wouldn't be able to do that in the limited environment on pythonanywhere, so I tried just setting `uwsgi = None` in `notifications.py` but that didn't work either. No errors, but no notifications either. I assume because threading is not supported on pythonanywhere, as stated in [this faq](https://help.pythonanywhere.com/pages/AsyncInWebApps/). They do mention that multiprocessing is supported and that worked in my tests.

My general solution was to pass through the `threading`, `multiprocessing` and `uwsgi` flags through and using them in the `notifications.py` module to handle thing appropriately. Works for me, using this code in production currently.