### PR TITLE
Removes potential '//' from email links (#420)

### DIFF
--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -77,6 +77,8 @@ class SMTP(object):
         self.isso = isso
         self.conf = isso.conf.section("smtp")
         self.public_endpoint = isso.conf.get("server", "public-endpoint") or local("host")
+        if self.public_endpoint.endswith('/'):
+            self.public_endpoint = self.public_endpoint.rstrip('/')
         self.admin_notify = any((n in ("smtp", "SMTP")) for n in isso.conf.getlist("general", "notify"))
         self.reply_notify = isso.conf.getboolean("general", "reply-notifications")
 


### PR DESCRIPTION
If the user specifies a public endpoint as `http[s]://comments.exemple.com/` in configuration, the trailing slash will involve a `//` in the generated email links.

This patch should deal about that.

(See #420 OP note.)

---

```
[...]

---
Delete comment: https://comments.exemple.com//id/X/delete/token
```

---

Feedback welcome !
Bye :wave: