### PR TITLE
Enable the generic migrate function

### DIFF
--- a/docs/docs/extras/advanced-migration.rst
+++ b/docs/docs/extras/advanced-migration.rst
@@ -1,0 +1,71 @@
+Advanced Migration
+==================
+
+In quickstart we saw you can import comments from Disqs or WordPress. But there
+are a many other comments system and you could be using one of them.
+
+Isso provides a way to import such comments, however it's up to you to :
+
+- dump comments
+- fit the data to the following JSON format
+
+.. code-block::
+
+    A list of threads, each item being a dict with the following data:
+
+    - id: a text representing the unique thread id (note: by default isso
+          associates this ID to the article URL, but it can be changed on
+          client side with "data-isso-id" - see :doc:`client configuration <../configuration/client>` )
+    - title: the title of the thread
+    - comments: the list of comments
+
+        Each item in that list of comments is a dict with the following data:
+
+        - id: an integer with the unique id of the comment inside the thread
+          (it can be repeated among different threads); this will be used to
+          order the comment inside the thread
+        - author: the author's name
+        - email: the author's email
+        - website: the author's website
+        - remote_addr: the author's IP
+        - created: a timestamp, in the format "%Y-%m-%d %H:%M:%S"
+
+Example:
+
+.. code-block:: json
+    [
+        {
+            "id": "/blog/article1",
+            "title": "First article!"
+            comments": [
+                {
+                    "author": "James",
+                    "created": "2018-11-28 17:24:23",
+                    "email": "email@mail.com",
+                    "id": "1",
+                    "remote_addr": "127.0.0.1",
+                    "text": "Great article!",
+                    "website": "http://fefzfzef.frzr"
+                },
+                {
+                    "author": "Harold",
+                    "created": "2018-11-28 17:58:03",
+                    "email": "email2@mail.com",
+                    "id": "2",
+                    "remote_addr": "",
+                    "text": "I hated it...",
+                    "website": ""
+                }
+            ]
+        }
+    ]
+
+Keep in mind that isso expects to have an array, so keep the opening and ending square bracket even if you have only one article thread!
+
+Next you can import you json dump:
+
+.. code-block:: sh
+
+    ~> isso -c /path/to/isso.cfg import -t generic comment-dump.json
+    [100%]  53 threads, 192 comments
+

--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -62,7 +62,7 @@ Migration
 
 Isso provides a tool for importing comments from Disqus_ or WordPress_.
 You can also import comments form any other comment system, but this topic is more
-complex and covered in :doc:`advanced migration <extra/advanced-migration>`.
+complex and covered in :doc:`advanced migration <extras/advanced-migration>`.
 
 To export your comments from Disqus, log into Disqus, go to your website, click
 on *Discussions* and select the *Export* tab. You'll receive an email with your

--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -72,9 +72,10 @@ export your data. It has been reported that WordPress may generate broken XML.
 Try to repair the file using ``xmllint`` before you continue with the import.
 
 For any other comment system you can use the generic JSON format. It's up to you
-to fit the format (see generic.json_ for an example):
+to fit to the format (see generic.json_ for an example):
 
 .. code-block::
+
     A list of threads, each item being a dict with the following data:
 
         - id: a text representing the unique thread id

--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -60,7 +60,8 @@ For more options, see :doc:`server <configuration/server>` and :doc:`client
 Migration
 ---------
 
-You can import comments from Disqus_ or WordPress_.
+You can import comments from Disqus_ or WordPress_. You can also import comments
+issued from any comment system but you have to stick a specific json format.
 
 To export your comments from Disqus, log into Disqus, go to your website, click
 on *Discussions* and select the *Export* tab. You'll receive an email with your
@@ -70,11 +71,33 @@ To export comments from your previous WordPress installation, go to *Tools*,
 export your data. It has been reported that WordPress may generate broken XML.
 Try to repair the file using ``xmllint`` before you continue with the import.
 
-Now import the XML dump:
+For any other comment system you can use the generic JSON format. It's up to you
+to fit the format (see isso/tests/generic.json for an example):
+
+.. code-block::
+    A list of threads, each item being a dict with the following data:
+
+        - id: a text representing the unique thread id
+        - title: the title of the thread
+        - comments: the list of comments
+
+    Each item in that list of comments is a dict with the following data:
+
+        - id: an integer with the unique id of the comment inside the thread
+          (it can be repeated among different threads); this will be used to
+          order the comment inside the thread
+        - author: the author's name
+        - email: the author's email
+        - website: the author's website
+        - remote_addr: the author's IP
+        - created: a timestamp, in the format "%Y-%m-%d %H:%M:%S"
+
+
+Now import the XML or JSON dump:
 
 .. code-block:: sh
 
-    ~> isso -c /path/to/isso.cfg import disqus-or-wordpress.xml
+    ~> isso -c /path/to/isso.cfg import -t [disqus|wordpress|generic] disqus-or-wordpress-or-generic.[xml|json]
     [100%]  53 threads, 192 comments
 
 .. _Disqus: https://disqus.com/

--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -72,7 +72,7 @@ export your data. It has been reported that WordPress may generate broken XML.
 Try to repair the file using ``xmllint`` before you continue with the import.
 
 For any other comment system you can use the generic JSON format. It's up to you
-to fit the format (see isso/tests/generic.json for an example):
+to fit the format (see generic.json_ for an example):
 
 .. code-block::
     A list of threads, each item being a dict with the following data:
@@ -97,11 +97,12 @@ Now import the XML or JSON dump:
 
 .. code-block:: sh
 
-    ~> isso -c /path/to/isso.cfg import -t [disqus|wordpress|generic] disqus-or-wordpress-or-generic.[xml|json]
+    ~> isso -c /path/to/isso.cfg import -t [disqus|wordpress|generic] comment-dump.[xml|json]
     [100%]  53 threads, 192 comments
 
 .. _Disqus: https://disqus.com/
 .. _WordPress: https://wordpress.org/
+.. _generic.json: https://github.com/posativ/isso/blob/master/isso/tests/generic.json
 
 Running Isso
 ------------

--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -60,8 +60,9 @@ For more options, see :doc:`server <configuration/server>` and :doc:`client
 Migration
 ---------
 
-You can import comments from Disqus_ or WordPress_. You can also import comments
-issued from any comment system but you have to stick a specific json format.
+Isso provides a tool for importing comments from Disqus_ or WordPress_.
+You can also import comments form any other comment system, but this topic is more
+complex and covered in :doc:`advanced migration <extra/advanced-migration>`.
 
 To export your comments from Disqus, log into Disqus, go to your website, click
 on *Discussions* and select the *Export* tab. You'll receive an email with your
@@ -71,39 +72,15 @@ To export comments from your previous WordPress installation, go to *Tools*,
 export your data. It has been reported that WordPress may generate broken XML.
 Try to repair the file using ``xmllint`` before you continue with the import.
 
-For any other comment system you can use the generic JSON format. It's up to you
-to fit to the format (see generic.json_ for an example):
-
-.. code-block::
-
-    A list of threads, each item being a dict with the following data:
-
-        - id: a text representing the unique thread id
-        - title: the title of the thread
-        - comments: the list of comments
-
-    Each item in that list of comments is a dict with the following data:
-
-        - id: an integer with the unique id of the comment inside the thread
-          (it can be repeated among different threads); this will be used to
-          order the comment inside the thread
-        - author: the author's name
-        - email: the author's email
-        - website: the author's website
-        - remote_addr: the author's IP
-        - created: a timestamp, in the format "%Y-%m-%d %H:%M:%S"
-
-
-Now import the XML or JSON dump:
+Now import the XML dump:
 
 .. code-block:: sh
 
-    ~> isso -c /path/to/isso.cfg import -t [disqus|wordpress|generic] comment-dump.[xml|json]
+    ~> isso -c /path/to/isso.cfg import -t [disqus|wordpress] disqus-or-wordpress.xml
     [100%]  53 threads, 192 comments
 
 .. _Disqus: https://disqus.com/
 .. _WordPress: https://wordpress.org/
-.. _generic.json: https://github.com/posativ/isso/blob/master/isso/tests/generic.json
 
 Running Isso
 ------------

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -225,7 +225,7 @@ def main():
     imprt.add_argument("-n", "--dry-run", dest="dryrun", action="store_true",
                        help="perform a trial run with no changes made")
     imprt.add_argument("-t", "--type", dest="type", default=None,
-                       choices=["disqus", "wordpress"], help="export type")
+                       choices=["disqus", "wordpress", "generic"], help="export type")
     imprt.add_argument("--empty-id", dest="empty_id", action="store_true",
                        help="workaround for weird Disqus XML exports, #135")
 

--- a/isso/migrate.py
+++ b/isso/migrate.py
@@ -269,9 +269,10 @@ class Generic(object):
 
         - id: an integer with the unique id of the comment inside the thread (it can be repeated
           among different threads); this will be used to order the comment inside the thread
-        - author: the author name
-        - email: the author email
-        - website: the authot's website
+        - author: the author's name
+        - email: the author's email
+        - website: the author's website
+        - remote_addr: the author's IP
         - created: a timestamp, in the format "%Y-%m-%d %H:%M:%S"
     """
 
@@ -351,6 +352,8 @@ def dispatch(type, db, dump, empty_id=False):
         cls = Disqus
     elif type == "wordpress":
         cls = WordPress
+    elif type == "generic":
+        cls = Generic
     else:
         with io.open(dump, encoding="utf-8") as fp:
             cls = autodetect(fp.read(io.DEFAULT_BUFFER_SIZE))


### PR DESCRIPTION
Greetings,

The script migrate.py is containing a tool for importing a generic format of comments.
But until now this tool was unreachable from isso binary.

These commits enable the usage of "generic" type of importation. Also I have added some documentation about how using it. The documentation part looks big, I am open to any simplifications.

Regards,
Matthieu