### PR TITLE
Implement #358 (Redirect to comment after moderation)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,5 +109,9 @@ In chronological order:
 * Craig P Hicks @craigphicks
   * Fix sub urls configurations on admin interface
 
+* Chris Warrick @Kwpolska
+  * Update Polish translation
+  * Redirect to comment after moderation
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -517,13 +517,14 @@ class API(object):
     @apiSuccessExample {html} Using GET:
         &lt;!DOCTYPE html&gt;
         &lt;html&gt;
-        &lt;head&gt;
-          &lt;title&gt;Successfully unsubscribed&lt;/title&gt;
-        &lt;/head&gt;
-        &lt;body&gt;
-          &lt;p&gt;You have been unsubscribed from replies in the given conversation.&lt;/p&gt;
-        &lt;/body&gt;
-        &lt;/html&gt;
+            &lt;head&gt;
+                &lt;script&gt;
+                    if (confirm('Delete: Are you sure?')) {
+                        xhr = new XMLHttpRequest;
+                        xhr.open('POST', window.location.href);
+                        xhr.send(null);
+                    }
+                &lt;/script&gt;
 
     @apiSuccessExample Using POST:
         Yo


### PR DESCRIPTION
This closes #358. After a comment is successfully moderated, the user is redirected to the comment page itself.