### PR TITLE
Mail subject customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Atom build
+.build-tools.cson
+flake.log

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ ENV/
 # Atom build
 .build-tools.cson
 flake.log
+.pylintrc

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -229,6 +229,35 @@ timeout
     specify a timeout in seconds for blocking operations like the
     connection attempt.
 
+Mail
+----
+
+configure the format the mail notification uses in SMTP section.
+
+.. code-block:: ini
+
+    [mail]
+    subject_admin = {title}
+    subject_user = Re: New comment posted on {title}
+
+subject_admin
+  	specify the subject format of the notification email sent to the admin.
+    Default: `{title}`
+    Available variables:
+    `{title}`: The title of the isso thread.
+    `{replier}`: The name of the author of the comment. If the author didn't fill in a
+    name, it will fallback to the term "Anonymous".
+
+subject_user
+  	specify the subject format of the notification email sent to the subscribed
+  	commenter.
+    Default: `Re: New comment posted on {title}`
+    Available variables:
+    `{title}`: The title of the isso thread.
+    `{replier}`: The name of the author of the comment. If the author didn't fill in a
+    name, it will fallback to the term "Anonymous".
+    `{receiver}`: The author whose comment is replied to in this situation.  If the
+    author didn't fill in a name, it will fallback to to the term "Anonymous".
 
 Guard
 -----

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -241,27 +241,42 @@ Configure the format the mail notification uses in the SMTP section.
     subject_user = Re: New comment posted on {title}
 
 subject_admin
-  	specify the subject format of the notification email sent to the admin.
+    specify the subject format of the notification email sent to the admin.
+
     Default: `{title}`
+
     Available variables:
-    `{title}`: The title of the isso thread.
-    `{replier}`: The name of the author of the comment. If the author has no name,
-    it will fallback to the term "Anonymous".
+
+    {title}
+        The title of the isso thread.
+
+    {replier}
+        The name of the author of the comment. If the author has no name,
+        it will fallback to the term "Anonymous".
 
 subject_user
-  	specify the subject format of the notification email sent to the subscribed
-  	commenter.
+    specify the subject format of the notification email sent to the subscribed
+    commenter. If it is set to two values, then the first one will be used when
+    `{repliee}`'s comment is not the `{receiver}`'s original one, the second one
+    will be used otherwise.
+
     Default: `Re: New comment posted on {title}`
+
     Available variables:
-    `{title}`: The title of the isso thread.
-    `{replier}`: The name of the author of the comment. If the author has no name,
-    it will fallback to the term "Anonymous".
-    `{repliee}`: The author whose comment is replied to.  If the author has no
-    name, it will fallback to the term "Anonymous".
-    `{receiver}`: The receiver of the email.
-    If it is set to two values, then the first one will be used when `{repliee}`'s
-    comment is not the `{receiver}`'s original one, the second one will be used
-    otherwise.
+
+    {title}
+        The title of the isso thread.
+
+    {replier}
+        The name of the author of the comment. If the author has no name,
+        it will fallback to the term "Anonymous".
+
+    {repliee}
+        The author whose comment is replied to.  If the author has no
+        name, it will fallback to the term "Anonymous".
+
+    {receiver}
+        The receiver of the email.
 
 Guard
 -----

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -256,8 +256,9 @@ subject_user
     `{title}`: The title of the isso thread.
     `{replier}`: The name of the author of the comment. If the author has no name,
     it will fallback to the term "Anonymous".
-    `{receiver}`: The author whose comment is replied to in this situation.  If the
-    author has no name, it will fallback to the term "Anonymous".
+    `{repliee}`: The author whose comment is replied to.  If the author has no
+    name, it will fallback to the term "Anonymous".
+    `{receiver}`: The receiver of the email.
 
 Guard
 -----

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -252,11 +252,30 @@ subject_admin
         The name of the author of the comment. If the author has no name,
         it will fallback to the term "Anonymous".
 
-subject_user
+subject_user_reply
     specify the subject format of the notification email sent to the subscribed
-    commenter. If it is set to two values, then the first one will be used when
-    ``{repliee}``'s comment is not the ``{receiver}``'s original one, the second one
-    will be used otherwise.
+    commenter when the new comment is a reply to his comment.
+    Default: ``Re: New comment posted on {title}``.
+    Available variables:
+
+    {title}
+        The title of the isso thread.
+
+    {replier}
+        The name of the author of the comment. If the author has no name,
+        it will fallback to the term "Anonymous".
+
+    {repliee}
+        The author whose comment is replied to.  If the author has no
+        name, it will fallback to the term "Anonymous".
+
+    {receiver}
+        The name of the recipient of the email.
+
+subject_user_new_comment
+    specify the subject format of the notification email sent to the subscribed
+    commenter whose comment is a reply to a comment when the new comment is also
+    a reply to that comment.
     Default: ``Re: New comment posted on {title}``.
     Available variables:
 

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -259,6 +259,9 @@ subject_user
     `{repliee}`: The author whose comment is replied to.  If the author has no
     name, it will fallback to the term "Anonymous".
     `{receiver}`: The receiver of the email.
+    If it is set to a list of two strings, then the first one will be used when
+    `{repliee}`'s comment is not the `{receiver}`'s original one, the second one will be used
+    otherwise.
 
 Guard
 -----

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -242,7 +242,7 @@ Configure the format the mail notification uses in the SMTP section.
 
 subject_admin
     specify the subject format of the notification email sent to the admin.
-    Default: ``{title}``. 
+    Default: ``{title}``.
     Available variables:
 
     {title}
@@ -272,7 +272,7 @@ subject_user
         name, it will fallback to the term "Anonymous".
 
     {receiver}
-        The receiver of the email.
+        The name of the recipient of the email.
 
 Guard
 -----

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -259,8 +259,8 @@ subject_user
     `{repliee}`: The author whose comment is replied to.  If the author has no
     name, it will fallback to the term "Anonymous".
     `{receiver}`: The receiver of the email.
-    If it is set to a list of two strings, then the first one will be used when
-    `{repliee}`'s comment is not the `{receiver}`'s original one, the second one will be used
+    If it is set to two values, then the first one will be used when `{repliee}`'s
+    comment is not the `{receiver}`'s original one, the second one will be used
     otherwise.
 
 Guard

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -238,7 +238,8 @@ Configure the format the mail notification uses in the SMTP section.
 
     [mail]
     subject_admin = {title}
-    subject_user = Re: New comment posted on {title}
+    subject_user_reply = Re: New comment posted on {title}
+    subject_user_new_comment = Re: New comment posted on {title}
 
 subject_admin
     specify the subject format of the notification email sent to the admin.

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -232,7 +232,7 @@ timeout
 Mail
 ----
 
-configure the format the mail notification uses in SMTP section.
+Configure the format the mail notification uses in the SMTP section.
 
 .. code-block:: ini
 
@@ -245,8 +245,8 @@ subject_admin
     Default: `{title}`
     Available variables:
     `{title}`: The title of the isso thread.
-    `{replier}`: The name of the author of the comment. If the author didn't fill in a
-    name, it will fallback to the term "Anonymous".
+    `{replier}`: The name of the author of the comment. If the author has no name,
+    it will fallback to the term "Anonymous".
 
 subject_user
   	specify the subject format of the notification email sent to the subscribed
@@ -254,10 +254,10 @@ subject_user
     Default: `Re: New comment posted on {title}`
     Available variables:
     `{title}`: The title of the isso thread.
-    `{replier}`: The name of the author of the comment. If the author didn't fill in a
-    name, it will fallback to the term "Anonymous".
+    `{replier}`: The name of the author of the comment. If the author has no name,
+    it will fallback to the term "Anonymous".
     `{receiver}`: The author whose comment is replied to in this situation.  If the
-    author didn't fill in a name, it will fallback to to the term "Anonymous".
+    author has no name, it will fallback to the term "Anonymous".
 
 Guard
 -----

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -242,9 +242,7 @@ Configure the format the mail notification uses in the SMTP section.
 
 subject_admin
     specify the subject format of the notification email sent to the admin.
-
-    Default: `{title}`
-
+    Default: ``{title}``. 
     Available variables:
 
     {title}
@@ -257,11 +255,9 @@ subject_admin
 subject_user
     specify the subject format of the notification email sent to the subscribed
     commenter. If it is set to two values, then the first one will be used when
-    `{repliee}`'s comment is not the `{receiver}`'s original one, the second one
+    ``{repliee}``'s comment is not the ``{receiver}``'s original one, the second one
     will be used otherwise.
-
-    Default: `Re: New comment posted on {title}`
-
+    Default: ``Re: New comment posted on {title}``.
     Available variables:
 
     {title}

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -151,20 +151,13 @@ class SMTP(object):
             return self.isso.conf.get("mail", "subject_admin").format(
                 title=thread["title"],
                 replier=comment["author"] or "Anonymous")
-        subject_format = list(self.isso.conf.getiter("mail", "subject_user"))
-        if len(subject_format) == 1:
-            return subject_format[0].format(
-                title=thread["title"],
-                repliee=parent_comment["author"] or "Anonymous",
-                replier=comment["author"] or "Anonymous",
-                receiver=recipient_comment["author"] or "Anonymous")
         if parent_comment["id"] == recipient_comment["id"]:
-            return subject_format[1].format(
+            return self.isso.conf.get("mail", "subject_user_reply").format(
                 title=thread["title"],
                 repliee=parent_comment["author"] or "Anonymous",
                 replier=comment["author"] or "Anonymous",
                 receiver=recipient_comment["author"] or "Anonymous")
-        return subject_format[0].format(
+        return self.isso.conf.get("mail", "subject_user_new_comment").format(
             title=thread["title"],
             repliee=parent_comment["author"] or "Anonymous",
             replier=comment["author"] or "Anonymous",

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -86,10 +86,7 @@ class SMTP(object):
             with SMTPConnection(self.conf):
                 logger.info("connected to SMTP server")
         except (socket.error, smtplib.SMTPException):
-            if os.path.join(dist.location, "isso", "tests", "test_mail.py") in sys.argv:
-                pass
-            else:
-                logger.exception("unable to connect to SMTP server")
+            logger.exception("unable to connect to SMTP server")
 
         if uwsgi:
             def spooler(args):

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -6,7 +6,6 @@ import sys
 import io
 import time
 import json
-import os.path
 
 import socket
 import smtplib

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -148,8 +148,11 @@ class SMTP(object):
 
     def notify_new(self, thread, comment):
         if self.admin_notify:
+            subject = self.isso.conf.get("mail", "subject_admin").format(
+                title=thread["title"],
+                replier=comment["author"] or self.no_name)
             body = self.format(thread, comment, None, admin=True)
-            self.sendmail(thread["title"], body, thread, comment)
+            self.sendmail(subject, body, thread, comment)
 
         if comment["mode"] == 1:
             self.notify_users(thread, comment)
@@ -169,7 +172,10 @@ class SMTP(object):
                 if "email" in comment_to_notify and comment_to_notify["notification"] and email not in notified \
                         and comment_to_notify["id"] != comment["id"] and email != comment["email"]:
                     body = self.format(thread, comment, parent_comment, email, admin=False)
-                    subject = "Re: New comment posted on %s" % thread["title"]
+                    subject = self.isso.conf.get("mail", "subject_user").format(
+                        title=thread["title"],
+                        receiver=parent_comment["author"] or self.no_name,
+                        replier=comment["author"] or self.no_name)
                     self.sendmail(subject, body, thread, comment, to=email)
                     notified.append(email)
 

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -100,6 +100,9 @@ class SMTP(object):
 
             uwsgi.spooler = spooler
 
+    def NO_NAME(self):
+        return "Anonymous"
+
     def __iter__(self):
         yield "comments.new:after-save", self.notify_new
         yield "comments.activate", self.notify_activated
@@ -108,7 +111,7 @@ class SMTP(object):
 
         rv = io.StringIO()
 
-        author = comment["author"] or "Anonymous"
+        author = comment["author"] or self.NO_NAME()
         if admin and comment["email"]:
             author += " <%s>" % comment["email"]
 
@@ -150,18 +153,18 @@ class SMTP(object):
         if admin:
             return self.isso.conf.get("mail", "subject_admin").format(
                 title=thread["title"],
-                replier=comment["author"] or "Anonymous")
+                replier=comment["author"] or self.NO_NAME())
         if parent_comment["id"] == recipient_comment["id"]:
             return self.isso.conf.get("mail", "subject_user_reply").format(
                 title=thread["title"],
-                repliee=parent_comment["author"] or "Anonymous",
-                replier=comment["author"] or "Anonymous",
-                receiver=recipient_comment["author"] or "Anonymous")
+                repliee=parent_comment["author"] or self.NO_NAME(),
+                replier=comment["author"] or self.NO_NAME(),
+                receiver=recipient_comment["author"] or self.NO_NAME())
         return self.isso.conf.get("mail", "subject_user_new_comment").format(
             title=thread["title"],
-            repliee=parent_comment["author"] or "Anonymous",
-            replier=comment["author"] or "Anonymous",
-            receiver=recipient_comment["author"] or "Anonymous")
+            repliee=parent_comment["author"] or self.NO_NAME(),
+            replier=comment["author"] or self.NO_NAME(),
+            receiver=recipient_comment["author"] or self.NO_NAME())
 
     def notify_new(self, thread, comment):
         if self.admin_notify:

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -109,9 +109,10 @@ class SMTP(object):
         yield "comments.new:after-save", self.notify_new
         yield "comments.activate", self.notify_activated
 
-    def format(self, thread, comment, parent_comment, recipient=None, admin=False):
+    def format(self, thread, comment, parent_comment, recipient=None):
 
         rv = io.StringIO()
+        admin = not parent_comment
 
         author = comment["author"] or "Anonymous"
         if admin and comment["email"]:
@@ -165,7 +166,7 @@ class SMTP(object):
     def notify_new(self, thread, comment):
         if self.admin_notify:
             subject = self.notify_subject(thread, comment)
-            body = self.format(thread, comment, None, admin=True)
+            body = self.format(thread, comment, None)
             self.sendmail(subject, body, thread, comment)
 
         if comment["mode"] == 1:

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -80,7 +80,6 @@ class SMTP(object):
         self.public_endpoint = isso.conf.get("server", "public-endpoint") or local("host")
         self.admin_notify = any((n in ("smtp", "SMTP")) for n in isso.conf.getlist("general", "notify"))
         self.reply_notify = isso.conf.getboolean("general", "reply-notifications")
-        self.no_name = "Anonymous"
 
         # test SMTP connectivity
         try:
@@ -112,7 +111,7 @@ class SMTP(object):
     def format(self, thread, comment, parent_comment, recipient=None):
 
         rv = io.StringIO()
-        admin = not parent_comment
+        admin = not recipient
 
         author = comment["author"] or "Anonymous"
         if admin and comment["email"]:
@@ -153,29 +152,29 @@ class SMTP(object):
         return rv.read()
 
     def notify_subject(self, thread, comment, parent_comment=None, recipient=None):
-        if parent_comment:
+        if recipient:
             subject_format = list(self.isso.conf.getiter("mail", "subject_user"))
             if len(subject_format) == 1:
                 return subject_format[0].format(
                     title=thread["title"],
-                    repliee=parent_comment["author"] or self.no_name,
-                    replier=comment["author"] or self.no_name,
-                    receiver=recipient["author"] or self.no_name)
+                    repliee=parent_comment["author"] or "Anonymous",
+                    replier=comment["author"] or "Anonymous",
+                    receiver=recipient["author"] or "Anonymous")
             if parent_comment["id"] == recipient["id"]:
                 return subject_format[1].format(
                     title=thread["title"],
-                    repliee=parent_comment["author"] or self.no_name,
-                    replier=comment["author"] or self.no_name,
-                    receiver=recipient["author"] or self.no_name)
+                    repliee=parent_comment["author"] or "Anonymous",
+                    replier=comment["author"] or "Anonymous",
+                    receiver=recipient["author"] or "Anonymous")
             return subject_format[0].format(
                 title=thread["title"],
-                repliee=parent_comment["author"] or self.no_name,
-                replier=comment["author"] or self.no_name,
-                receiver=recipient["author"] or self.no_name)
+                repliee=parent_comment["author"] or "Anonymous",
+                replier=comment["author"] or "Anonymous",
+                receiver=recipient["author"] or "Anonymous")
         else:
             return self.isso.conf.get("mail", "subject_admin").format(
                 title=thread["title"],
-                replier=comment["author"] or self.no_name)
+                replier=comment["author"] or "Anonymous")
 
     def notify_new(self, thread, comment):
         if self.admin_notify:

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -79,6 +79,7 @@ class SMTP(object):
         self.public_endpoint = isso.conf.get("server", "public-endpoint") or local("host")
         self.admin_notify = any((n in ("smtp", "SMTP")) for n in isso.conf.getlist("general", "notify"))
         self.reply_notify = isso.conf.getboolean("general", "reply-notifications")
+        self.no_name = "Anonymous"
 
         # test SMTP connectivity
         try:

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -28,7 +28,7 @@ except ImportError:
     uwsgi = None
 
 from isso.compat import PY2K
-from isso import local, dist
+from isso import local
 
 if PY2K:
     from thread import start_new_thread

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -154,7 +154,20 @@ class SMTP(object):
 
     def notify_subject(self, thread, comment, parent_comment=None, recipient=None):
         if parent_comment:
-            return self.isso.conf.get("mail", "subject_user").format(
+            subject_format = list(self.isso.conf.getiter("mail", "subject_user"))
+            if len(subject_format) == 1:
+                return subject_format[0].format(
+                    title=thread["title"],
+                    repliee=parent_comment["author"] or self.no_name,
+                    replier=comment["author"] or self.no_name,
+                    receiver=recipient["author"] or self.no_name)
+            if parent_comment["id"] == recipient["id"]:
+                return subject_format[1].format(
+                    title=thread["title"],
+                    repliee=parent_comment["author"] or self.no_name,
+                    replier=comment["author"] or self.no_name,
+                    receiver=recipient["author"] or self.no_name)
+            return subject_format[0].format(
                 title=thread["title"],
                 repliee=parent_comment["author"] or self.no_name,
                 replier=comment["author"] or self.no_name,

--- a/isso/tests/test_mail.py
+++ b/isso/tests/test_mail.py
@@ -1,0 +1,94 @@
+# -*- encoding: utf-8 -*-
+
+# Test mail format customization
+
+from __future__ import unicode_literals
+
+import unittest
+import os
+import json
+import tempfile
+
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+
+from werkzeug.wrappers import Response
+from isso import Isso, core, config, local, dist
+from isso.utils import http
+from fixtures import curl, loads, FakeIP, JSONClient
+http.curl = curl
+
+from isso.ext.notifications import SMTP
+
+
+class TestMail(unittest.TestCase):
+
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp()
+        conf = config.load(os.path.join(dist.location, "share", "isso.conf"))
+        conf.set("general", "dbpath", self.path)
+        conf.set("guard", "enabled", "off")
+        conf.set("hash", "algorithm", "none")
+
+        self.conf = conf
+
+        class App(Isso, core.Mixin):
+            pass
+
+        self.app = App(conf)
+        self.app.wsgi_app = FakeIP(self.app.wsgi_app, "192.168.1.1")
+
+        self.client = JSONClient(self.app, Response)
+        self.get = self.client.get
+        self.put = self.client.put
+        self.post = self.client.post
+        self.delete = self.client.delete
+        self.public_endpoint = conf.get("server", "public-endpoint") or local("host")
+
+        self.smtp = SMTP(self.app)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def testSubject_default(self):
+        """Test subject default parsing"""
+        thread_test = {"uri": "/aaa", "title": "Hello isso!"}
+        pa = self.post(
+            '/new?uri=%2Fpath%2F',
+            data=json.dumps({"text": "From Anonymous", }))
+        rv = self.post(
+            '/new?uri=%2Fpath%2F',
+            data=json.dumps(
+                {"text": "THis is a sub-class comment",
+                 "author": "Sim",
+                 "website": "https://snorl.ax",
+                 "parent": 1}))
+        pa = loads(pa.data)
+        rv = loads(rv.data)
+
+        self.assertEqual(self.smtp.notify_subject(thread_test, rv, parent_comment=pa), "Re: New comment posted on %s" % thread_test["title"])
+        self.assertEqual(self.smtp.notify_subject(thread_test, pa), thread_test["title"])
+
+    def testSubject_customization(self):
+        """Test subject customization parsing"""
+        self.conf.set("mail", "subject_user", "{receiver}, {replier} replied to your comment on the post {title}")
+        self.conf.set("mail", "subject_admin", "{replier} commented on your post {title}")
+        self.smtp = SMTP(self.app)
+        thread_test = {"uri": "/aaa", "title": "Hello isso!"}
+        pa = self.post(
+            '/new?uri=%2Fpath%2F',
+            data=json.dumps({"text": "From Anonymous", }))
+        rv = self.post(
+            '/new?uri=%2Fpath%2F',
+            data=json.dumps(
+                {"text": "THis is a sub-class comment",
+                 "author": "Sim",
+                 "website": "https://snorl.ax",
+                 "parent": 1}))
+        pa = loads(pa.data)
+        rv = loads(rv.data)
+
+        self.assertEqual(self.smtp.notify_subject(thread_test, rv, parent_comment=pa), "Anonymous, Sim replied to your comment on the post Hello isso!")
+        self.assertEqual(self.smtp.notify_subject(thread_test, pa), "Anonymous commented on your post Hello isso!")

--- a/isso/tests/test_mail.py
+++ b/isso/tests/test_mail.py
@@ -64,7 +64,7 @@ class TestMail(unittest.TestCase):
         rv = loads(rv.data)
 
         self.assertEqual(self.smtp.notify_subject(thread_test, rv, pa, pa), "Re: New comment posted on %s" % thread_test["title"])
-        self.assertEqual(self.smtp.notify_subject(thread_test, pa), thread_test["title"])
+        self.assertEqual(self.smtp.notify_subject(thread_test, pa, admin=True), thread_test["title"])
 
     def testSubject_customization(self):
         """Test subject customization parsing"""
@@ -86,4 +86,4 @@ class TestMail(unittest.TestCase):
         rv = loads(rv.data)
 
         self.assertEqual(self.smtp.notify_subject(thread_test, rv, pa, pa), "Sim replied to your comment on the post Hello isso!")
-        self.assertEqual(self.smtp.notify_subject(thread_test, pa), "Anonymous commented on your post Hello isso!")
+        self.assertEqual(self.smtp.notify_subject(thread_test, pa, admin=True), "Anonymous commented on your post Hello isso!")

--- a/isso/tests/test_mail.py
+++ b/isso/tests/test_mail.py
@@ -68,7 +68,7 @@ class TestMail(unittest.TestCase):
 
     def testSubject_customization(self):
         """Test subject customization parsing"""
-        self.conf.set("mail", "subject_user", "{receiver}, {replier} replied to {repliee}'s comment on the post {title}")
+        self.conf.set("mail", "subject_user", "{receiver}, {replier} replied to {repliee}'s comment on the post {title}\n{replier} replied to your comment on the post {title}")
         self.conf.set("mail", "subject_admin", "{replier} commented on your post {title}")
         self.smtp = SMTP(self.app)
         thread_test = {"uri": "/aaa", "title": "Hello isso!"}
@@ -85,5 +85,5 @@ class TestMail(unittest.TestCase):
         pa = loads(pa.data)
         rv = loads(rv.data)
 
-        self.assertEqual(self.smtp.notify_subject(thread_test, rv, pa, pa), "Anonymous, Sim replied to Anonymous's comment on the post Hello isso!")
+        self.assertEqual(self.smtp.notify_subject(thread_test, rv, pa, pa), "Sim replied to your comment on the post Hello isso!")
         self.assertEqual(self.smtp.notify_subject(thread_test, pa), "Anonymous commented on your post Hello isso!")

--- a/isso/tests/test_mail.py
+++ b/isso/tests/test_mail.py
@@ -9,11 +9,6 @@ import os
 import json
 import tempfile
 
-try:
-    from urllib.parse import quote
-except ImportError:
-    from urllib import quote
-
 from werkzeug.wrappers import Response
 from isso import Isso, core, config, local, dist
 from isso.utils import http

--- a/isso/tests/test_mail.py
+++ b/isso/tests/test_mail.py
@@ -13,9 +13,8 @@ from werkzeug.wrappers import Response
 from isso import Isso, core, config, local, dist
 from isso.utils import http
 from fixtures import curl, loads, FakeIP, JSONClient
-http.curl = curl
-
 from isso.ext.notifications import SMTP
+http.curl = curl
 
 
 class TestMail(unittest.TestCase):

--- a/isso/tests/test_mail.py
+++ b/isso/tests/test_mail.py
@@ -63,12 +63,12 @@ class TestMail(unittest.TestCase):
         pa = loads(pa.data)
         rv = loads(rv.data)
 
-        self.assertEqual(self.smtp.notify_subject(thread_test, rv, parent_comment=pa), "Re: New comment posted on %s" % thread_test["title"])
+        self.assertEqual(self.smtp.notify_subject(thread_test, rv, pa, pa), "Re: New comment posted on %s" % thread_test["title"])
         self.assertEqual(self.smtp.notify_subject(thread_test, pa), thread_test["title"])
 
     def testSubject_customization(self):
         """Test subject customization parsing"""
-        self.conf.set("mail", "subject_user", "{receiver}, {replier} replied to your comment on the post {title}")
+        self.conf.set("mail", "subject_user", "{receiver}, {replier} replied to {repliee}'s comment on the post {title}")
         self.conf.set("mail", "subject_admin", "{replier} commented on your post {title}")
         self.smtp = SMTP(self.app)
         thread_test = {"uri": "/aaa", "title": "Hello isso!"}
@@ -85,5 +85,5 @@ class TestMail(unittest.TestCase):
         pa = loads(pa.data)
         rv = loads(rv.data)
 
-        self.assertEqual(self.smtp.notify_subject(thread_test, rv, parent_comment=pa), "Anonymous, Sim replied to your comment on the post Hello isso!")
+        self.assertEqual(self.smtp.notify_subject(thread_test, rv, pa, pa), "Anonymous, Sim replied to Anonymous's comment on the post Hello isso!")
         self.assertEqual(self.smtp.notify_subject(thread_test, pa), "Anonymous commented on your post Hello isso!")

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -146,7 +146,8 @@ timeout = 10
 subject_admin = {title}
 
 # specify the subject format of the notification email sent to the subscribed
-# commenter. Default: Re: New comment posted on {title}
+# commenter when the new comment is a reply to his comment.
+# Default: Re: New comment posted on {title}
 # Available variables:
 # {title}: The title of the isso thread.
 # {replier}: The name of the author of the comment. If the author has no name,
@@ -157,8 +158,23 @@ subject_admin = {title}
 # If it is set to two values, then the first one will be used when {repliee}'s
 # comment is not the {receiver}'s original one, the second one will be used
 # otherwise.
-subject_user = Re: New comment posted on {title}
+subject_user_reply = Re: New comment posted on {title}
 
+# specify the subject format of the notification email sent to the subscribed
+# commenter whose comment is a reply to a comment when the new comment is also
+# a reply to that comment.
+# Default: Re: New comment posted on {title}
+# Available variables:
+# {title}: The title of the isso thread.
+# {replier}: The name of the author of the comment. If the author has no name,
+# it will fallback to the term "Anonymous".
+# {repliee}: The author whose comment is replied to.  If the author has no
+# name, it will fallback to the term "Anonymous".
+# {receiver}: The name of the recipient of the email.
+# If it is set to two values, then the first one will be used when {repliee}'s
+# comment is not the {receiver}'s original one, the second one will be used
+# otherwise.
+subject_user_new_comment = Re: New comment posted on {title}
 
 [guard]
 # Enable basic spam protection features, e.g. rate-limit per IP address (/24

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -154,8 +154,8 @@ subject_admin = {title}
 # {repliee}: The author whose comment is replied to.  If the author has no
 # name, it will fallback to the term "Anonymous".
 # {receiver}: The receiver of the email.
-# If it is set to a list of two strings, then the first one will be used when
-# {repliee}'s comment is not the {receiver}'s original one, the second one will be used
+# If it is set to two values, then the first one will be used when {repliee}'s
+# comment is not the {receiver}'s original one, the second one will be used
 # otherwise.
 subject_user = Re: New comment posted on {title}
 

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -154,6 +154,9 @@ subject_admin = {title}
 # {repliee}: The author whose comment is replied to.  If the author has no
 # name, it will fallback to the term "Anonymous".
 # {receiver}: The receiver of the email.
+# If it is set to a list of two strings, then the first one will be used when
+# {repliee}'s comment is not the {receiver}'s original one, the second one will be used
+# otherwise.
 subject_user = Re: New comment posted on {title}
 
 

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -151,8 +151,9 @@ subject_admin = {title}
 # {title}: The title of the isso thread.
 # {replier}: The name of the author of the comment. If the author has no name,
 # it will fallback to the term "Anonymous".
-# {receiver}: The author whose comment is replied to in this situation.  If the
-# author has no name, it will fallback to the term "Anonymous".
+# {repliee}: The author whose comment is replied to.  If the author has no
+# name, it will fallback to the term "Anonymous".
+# {receiver}: The receiver of the email.
 subject_user = Re: New comment posted on {title}
 
 

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -153,7 +153,7 @@ subject_admin = {title}
 # it will fallback to the term "Anonymous".
 # {repliee}: The author whose comment is replied to.  If the author has no
 # name, it will fallback to the term "Anonymous".
-# {receiver}: The receiver of the email.
+# {receiver}: The name of the recipient of the email.
 # If it is set to two values, then the first one will be used when {repliee}'s
 # comment is not the {receiver}'s original one, the second one will be used
 # otherwise.

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -135,24 +135,24 @@ timeout = 10
 
 
 [mail]
-# configure the format the mail notification uses in SMTP section.
+# Configure the format the mail notification uses in the SMTP section.
 #
 
 # specify the subject format of the notification email sent to the admin. Default: {title}
 # Available variables:
 # {title}: The title of the isso thread.
-# {replier}: The name of the author of the comment. If the author didn't fill in a Name
-# blank, it will fallback to the term "Anonymous".
+# {replier}: The name of the author of the comment. If the author has no name,
+# it will fallback to the term "Anonymous".
 subject_admin = {title}
 
 # specify the subject format of the notification email sent to the subscribed
 # commenter. Default: Re: New comment posted on {title}
 # Available variables:
 # {title}: The title of the isso thread.
-# {replier}: The name of the author of the comment. If the author didn't fill in a Name
-# blank, it will fallback to the term "Anonymous".
+# {replier}: The name of the author of the comment. If the author has no name,
+# it will fallback to the term "Anonymous".
 # {receiver}: The author whose comment is replied to in this situation.  If the
-# author didn't fill in a name, it will fallback to the term "Anonymous".
+# author has no name, it will fallback to the term "Anonymous".
 subject_user = Re: New comment posted on {title}
 
 

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -134,6 +134,28 @@ from =
 timeout = 10
 
 
+[mail]
+# configure the format the mail notification uses in SMTP section.
+#
+
+# specify the subject format of the notification email sent to the admin. Default: {title}
+# Available variables:
+# {title}: The title of the isso thread.
+# {replier}: The name of the author of the comment. If the author didn't fill in a Name
+# blank, it will fallback to the term "Anonymous".
+subject_admin = {title}
+
+# specify the subject format of the notification email sent to the subscribed
+# commenter. Default: Re: New comment posted on {title}
+# Available variables:
+# {title}: The title of the isso thread.
+# {replier}: The name of the author of the comment. If the author didn't fill in a Name
+# blank, it will fallback to the term "Anonymous".
+# {receiver}: The author whose comment is replied to in this situation.  If the
+# author didn't fill in a name, it will fallback to the term "Anonymous".
+subject_user = Re: New comment posted on {title}
+
+
 [guard]
 # Enable basic spam protection features, e.g. rate-limit per IP address (/24
 # for IPv4, /48 for IPv6).


### PR DESCRIPTION
## Subject Customization  

To customize the mail title, set like the following options in the mail block of the isso server conf:  

	[mail]
	...
	subject_admin = {replier} commented on {title}
	subject_user_new_comment = {receiver}, {replier} replied {repliee}'s comments on {title}
	subject_user_reply = {replier} replied to your comments on {title}

In the example, `subject_user` is set to two values, then the first one will be used when {repliee}'s comment is not the {receiver}'s original one, the second one will be used otherwise. 
`subject_user` can be set to a value, then the value will be used all the time in the reply notification.

**Result:**  
![](https://static.snorl.ax/isso-noti/20181230/def/url_mod.png)
![](https://static.snorl.ax/isso-noti/2019-05-29-231817_1920x1080_scrot.png)
![](https://static.snorl.ax/isso-noti/2019-05-29-231818_1920x1080_scrot.png)

I'll open pull requests about new features to the newly created mail block once the PR is merged. If you wanna test, you can check [it](https://github.com/posativ/isso/pull/518) out in advance.