### PR TITLE
[WIP] add simple systemd startup script with no dependencies

### DIFF
--- a/share/isso.service
+++ b/share/isso.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=lightweight Disqus alternative
+
+[Service]
+Type=simple
+User=isso
+ExecStart=/opt/isso/bin/isso -c /opt/isso/conf/isso.ini run
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The docs were lacking a systemd script that just starts isso without gunicorn so I thought I could add mine. If it is not wanted to have the file in the main repo, please deny this PR with an according comment and I will instead add it to my fork and add a link to the docs.