### PR TITLE
Return 200 with empty array when there are no comments #301

### DIFF
--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -769,8 +769,6 @@ class API(object):
             root_list = []
         else:
             root_list = list(self.comments.fetch(**args))
-            if not root_list:
-                raise NotFound
 
         if root_id not in reply_counts:
             reply_counts[root_id] = 0


### PR DESCRIPTION
For some of us who are picky about 404s, the API returns 404 when there are no comments. The not found exception was removed and the endpoint returns empty as expected with HTTP status 200.

`{"id": null, "total_replies": 0, "hidden_replies": 0, "replies": []}`