### PR TITLE
fix typo

### DIFF
--- a/isso/js/app/i18n.js
+++ b/isso/js/app/i18n.js
@@ -1,7 +1,7 @@
 define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/da",
         "app/i18n/de", "app/i18n/en", "app/i18n/fa", "app/i18n/fi",
         "app/i18n/fr", "app/i18n/hr",  "app/i18n/hu", "app/i18n/ru", "app/i18n/it",
-        "app/i18n/eo", "app/i18n/oc" "app/i18n/pl", "app/i18n/sk", "app/i18n/sv", "app/i18n/nl", "app/i18n/el_GR",
+        "app/i18n/eo", "app/i18n/oc", "app/i18n/pl", "app/i18n/sk", "app/i18n/sv", "app/i18n/nl", "app/i18n/el_GR",
         "app/i18n/es", "app/i18n/vi", "app/i18n/zh_CN", "app/i18n/zh_CN", "app/i18n/zh_TW"],
         function(config, bg, cs, da, de, en, fa, fi, fr, hr, hu, ru, it, eo, oc, pl, sk, sv, nl, el, es, vi, zh, zh_CN, zh_TW) {
 


### PR DESCRIPTION
without this PR:

```

almond#0.3.3 components/almond
r.js -o isso/js/build.embed.js out=isso/js/embed.min.js

Tracing dependencies for: components/almond/almond
Error: Parse error using esprima for file: /src/isso/js/app/i18n.js
Error: Line 4: Unexpected string
In module tree:
    embed

Error: Error: Parse error using esprima for file: /src/isso/js/app/i18n.js
Error: Line 4: Unexpected string
In module tree:
    embed

    at /usr/local/lib/node_modules/requirejs/bin/r.js:27728:47

Makefile:43: recipe for target 'isso/js/embed.min.js' failed
make: *** [isso/js/embed.min.js] Error 1
The command '/bin/sh -c make init js' returned a non-zero code: 2
time="2019-09-29T20:47:44Z" level=fatal msg="exit status 2"
```