### PR TITLE
Auto moderate known authors

### DIFF
--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -124,12 +124,17 @@ Enable moderation queue and handling of comments still in moderation queue
 
     [moderation]
     enabled = false
+    approve-if-email-previously-approved = false
     purge-after = 30d
 
 enabled
     enable comment moderation queue. This option only affects new comments.
     Comments in moderation queue are not visible to other users until you
     activate them.
+
+approve-if-email-previously-approved
+    automatically approve comments by an author if that author has had a
+    comment approved within the last 6 months.
 
 purge-after
     remove unprocessed comments in moderation queue after given time.

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -133,8 +133,11 @@ enabled
     activate them.
 
 approve-if-email-previously-approved
-    automatically approve comments by an author if that author has had a
-    comment approved within the last 6 months.
+    automatically approve comments by an email address if that address has
+    had a comment approved within the last 6 months. No ownership verification
+    is done on the entered email address. This means that if someone is able
+    to guess correctly the email address used by a previously approved author,
+    they will be able to have their new comment auto-approved.
 
 purge-after
     remove unprocessed comments in moderation queue after given time.

--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -86,9 +86,10 @@ class Comments:
         Search for previously activated comments with this author email.
         """
 
-        # if the user has not entered email, email == None in which case we can't check if they have previous comments
+        # if the user has not entered email, email == None, in which case we can't check if they have previous comments
         # in addition, we will only check for a matching email if the passed string is 3 chars or longer.
-        # we can only do len() on a string, so we use that check, which of course also ensures it's not None
+        # here we ensure that we only do this check if email is a string, which both excludes None,
+        # and ensures that this code correctly ignores other types that might accidentally be passed
         if type(email) is str and len(email) >= 3:
             # search for any activated comments within the last 6 months by email
             # this SQL should be one of the fastest ways of doing this check

--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -86,6 +86,9 @@ class Comments:
         Search for previously activated comments with this author email.
         """
 
+        # if the user has not entered email, email == None in which case we can't check if they have previous comments
+        # in addition, we will only check for a matching email if the passed string is 3 chars or longer.
+        # we can only do len() on a string, so we use that check, which of course also ensures it's not None
         if type(email) is str and len(email) >= 3:
             # search for any activated comments within the last 6 months by email
             # this SQL should be one of the fastest ways of doing this check

--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -87,12 +87,14 @@ class Comments:
         """
 
         if type(email) is str and len(email) >= 3:
-            # this SQL should be one of the fastest ways of determining if
-            # there's at least one comment with the given email and activation
+            # search for any activated comments within the last 6 months by email
+            # this SQL should be one of the fastest ways of doing this check
             # https://stackoverflow.com/questions/18114458/fastest-way-to-determine-if-record-exists
-            rv = self.db.execute(
-                'SELECT CASE WHEN EXISTS(select * from comments where email=? and mode=1) THEN 1 ELSE 0 END;', (email, )).fetchone()
-            print(rv)
+            rv = self.db.execute([
+                'SELECT CASE WHEN EXISTS(',
+                '    select * from comments where email=? and mode=1 and ',
+                '    created > strftime("%s", DATETIME("now", "-6 month"))',
+                ') THEN 1 ELSE 0 END;', (email,)).fetchone()
             return rv[0] == 1
 
         else:

--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -81,6 +81,23 @@ class Comments:
             '    mode=1',
             'WHERE id=? AND mode=2'], (id, ))
 
+    def is_previously_approved_author(self, email):
+        """
+        Search for previously activated comments with this author email.
+        """
+
+        if type(email) is str and len(email) >= 3:
+            # this SQL should be one of the fastest ways of determining if
+            # there's at least one comment with the given email and activation
+            # https://stackoverflow.com/questions/18114458/fastest-way-to-determine-if-record-exists
+            rv = self.db.execute(
+                'SELECT CASE WHEN EXISTS(select * from comments where email=? and mode=1) THEN 1 ELSE 0 END;', (email, )).fetchone()
+            print(rv)
+            return rv[0] == 1
+
+        else:
+            return False
+
     def unsubscribe(self, email, id):
         """
         Turn off email notifications for replies to this comment.

--- a/isso/db/comments.py
+++ b/isso/db/comments.py
@@ -94,7 +94,7 @@ class Comments:
                 'SELECT CASE WHEN EXISTS(',
                 '    select * from comments where email=? and mode=1 and ',
                 '    created > strftime("%s", DATETIME("now", "-6 month"))',
-                ') THEN 1 ELSE 0 END;', (email,)).fetchone()
+                ') THEN 1 ELSE 0 END;'], (email,)).fetchone()
             return rv[0] == 1
 
         else:

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -298,8 +298,7 @@ class API(object):
         with self.isso.lock:
             # if email-based auto-moderation enabled, check for previously approved author
             # right before approval.
-            if self.activate_if_email_previously_approved and \
-                self.comments.is_previously_approved_author(data['email']):
+            if self.activate_if_email_previously_approved and self.comments.is_previously_approved_author(data['email']):
                 data['mode'] = 1
 
             rv = self.comments.add(uri, data)

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -133,7 +133,7 @@ class API(object):
         self.conf = isso.conf.section("general")
         self.moderated = isso.conf.getboolean("moderation", "enabled")
         # this is similar to the wordpress setting "Comment author must have a previously approved comment"
-        self.activate_if_email_previously_approved = isso.conf.getboolean("moderation", "activate-if-email-previously-approved")
+        self.approve_if_email_previously_approved = isso.conf.getboolean("moderation", "approve-if-email-previously-approved")
 
         self.guard = isso.db.guard
         self.threads = isso.db.threads
@@ -298,7 +298,7 @@ class API(object):
         with self.isso.lock:
             # if email-based auto-moderation enabled, check for previously approved author
             # right before approval.
-            if self.activate_if_email_previously_approved and self.comments.is_previously_approved_author(data['email']):
+            if self.approve_if_email_previously_approved and self.comments.is_previously_approved_author(data['email']):
                 data['mode'] = 1
 
             rv = self.comments.add(uri, data)

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -71,9 +71,9 @@ password = please_choose_a_strong_password
 # them.
 enabled = false
 
-# with moderation enabled, automatically approve new posts by a
-# previously approved author
-activate-if-email-previously-approved = false
+# with moderation enabled, automatically approve new comments by an
+# author if they've had comments approved within the last 6 months
+approve-if-email-previously-approved = false
 
 # remove unprocessed comments in moderation queue after given time.
 purge-after = 30d

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -73,6 +73,12 @@ enabled = false
 
 # with moderation enabled, automatically approve new comments by an
 # author if they've had comments approved within the last 6 months
+# Note: No verification is done on the email addresses entered by commenters.
+# This means that if someone is able to guess correctly the email address used
+# by a previously approved author, they will be able to have their new comment
+# auto-approved. For this reason, we recommend that you also activate SMTP
+# notification if you activate this option, so that you will see
+# auto-approved comments as they get posted.
 approve-if-email-previously-approved = false
 
 # remove unprocessed comments in moderation queue after given time.

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -71,6 +71,10 @@ password = please_choose_a_strong_password
 # them.
 enabled = false
 
+# with moderation enabled, automatically approve new posts by a
+# previously approved author
+activate-if-email-previously-approved = false
+
 # remove unprocessed comments in moderation queue after given time.
 purge-after = 30d
 


### PR DESCRIPTION
This implements an option for the wordpress moderation feature where new comments by authors who have had approved comments are auto-approved.

In addition, I have made it so that when this option is active, the author needs to have had an approved comment within the last 6 months.

I have been testing this on https://cpbotha.net/ for almost two weeks now.