### PR TITLE
Fix rendering of disabled.html for 'Sub URI' sites

### DIFF
--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -1074,7 +1074,8 @@ class API(object):
 
     def login(self, env, req):
         if not self.isso.conf.getboolean("admin", "enabled"):
-            return render_template('disabled.html')
+            isso_host_script = self.isso.conf.get("server", "public-endpoint") or local.host
+            return render_template('disabled.html', isso_host_script=isso_host_script)
         data = req.form
         password = self.isso.conf.get("admin", "password")
         if data['password'] and data['password'] == password:
@@ -1096,7 +1097,7 @@ class API(object):
     def admin(self, env, req):
         isso_host_script = self.isso.conf.get("server", "public-endpoint") or local.host
         if not self.isso.conf.getboolean("admin", "enabled"):
-            return render_template('disabled.html')
+            return render_template('disabled.html', isso_host_script=isso_host_script)
         try:
             data = self.isso.unsign(req.cookies.get('admin-session', ''),
                                     max_age=60 * 60 * 24)


### PR DESCRIPTION
The disabled.html template uses the isso_host_script variable, but
that variable was not being passed when rendering that template
file.