### PR TITLE
Improved Grammar of index.rst

### DIFF
--- a/docs/docs/index.rst
+++ b/docs/docs/index.rst
@@ -2,7 +2,7 @@ Overview
 ========
 
 Welcome to Isso's documentation. This documentation will help you get started
-fast. If you get any problems when using Isso, you can find the answer in
+fast. If you run into any problems when using Isso, you can find the answer in
 troubleshooting guide or you can ask me on IRC or GitHub.
 
 Documentation overview:


### PR DESCRIPTION
Replaced 'get' with 'run into' as it is more grammatically correct. 