### PR TITLE
Use <pre> for comments in admin area

### DIFF
--- a/isso/css/admin.css
+++ b/isso/css/admin.css
@@ -113,6 +113,9 @@ a {
   text-align: center;
   width: 100%;
 }
+.isso-comment pre {
+    white-space: pre-wrap;
+}
 .isso-comment-footer a {
   cursor: pointer;
 }

--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -123,7 +123,7 @@
         {% if comment.mode == 4 %}
           <strong>HIDDEN</strong>. Original text: <br />
         {% endif %}
-        <div id="isso-text-{{comment.id}}">{{comment.text}}</div>
+        <div id="isso-text-{{comment.id}}"><pre>{{comment.text}}</pre></div>
       </div>
       <div class='isso-comment-footer'>
         {% if conf.votes and comment.likes - comment.dislikes != 0 %}


### PR DESCRIPTION
Also update `admin.css` so that lines get wrapped

Note that `document.getElementById().textContent()` already overlooks the `<pre>` tags, so there is no need to strip them when using [send_edit()](https://github.com/posativ/isso/blob/5655f194b311c50126713e6f40440e7f89be6479/isso/js/admin.js#L92).

This is a dirty fix, but adding the client-side `contenteditable` mechanism here is something I'm not prepared to do. If anyone wants to pick this up, feel free to do so!