### PR TITLE
html: Add markdown render flags option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOX_ENV=py37
+    - python: 3.8
+      dist: bionic
+      env: TOX_ENV=py38
 install:
   - pip install -U pip
   - pip install flake8 tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog for Isso
 0.12.3 (UNRELEASED)
 -------------------
 
+- New "flags" option in the [markdown] section to customize Misaka's Markdown
+  HTML rendering. By default, no flags are set.
+
+      [markup]
+      flags = skip-html, escape, hard-wrap
+
+  Check docs/configuration/server.rst for more details.
+
 0.12.2 (2019-01-21)
 -------------------
 

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -294,12 +294,20 @@ supported, but new languages are relatively easy to add.
 
     [markup]
     options = strikethrough, superscript, autolink
+    flags = skip-html, escape, hard-wrap
     allowed-elements =
     allowed-attributes =
 
 options
-    `Misaka-specific Markdown extensions <http://misaka.61924.nl/#api>`_, all
-    flags starting with `EXT_` can be used there, separated by comma.
+    `Misaka-specific Markdown extensions <https://misaka.61924.nl/#api>`_, all
+    extension flags can be used there, separated by comma, either by their name
+    or as `EXT_`_.
+
+flags
+    `Misaka-specific HTML rendering flags
+    <https://misaka.61924.nl/#html-render-flags>`_, all html rendering flags
+    can be used here, separated by comma, either by their name or as `HTML_`_.
+    Per Misaka's defaults, no flags are set.
 
 allowed-elements
     Additional HTML tags to allow in the generated output, comma-separated. By

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -369,8 +369,15 @@ class TestComments(unittest.TestCase):
         data = rv.data.decode('utf-8')
         data = re.sub('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+Z',
                       '2018-04-01T10:00:00Z', data)
-        self.assertEqual(data, """<?xml version=\'1.0\' encoding=\'utf-8\'?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"><updated>2018-04-01T10:00:00Z</updated><id>tag:example.org,2018:/isso/thread/path/</id><title>Comments for example.org/path/</title><entry><id>tag:example.org,2018:/isso/1/2</id><title>Comment #2</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-2" /><content type="html">&lt;p&gt;&lt;em&gt;Second&lt;/em&gt;&lt;/p&gt;</content><thr:in-reply-to href="https://example.org/path/#isso-1" ref="tag:example.org,2018:/isso/1/1" /></entry><entry><id>tag:example.org,2018:/isso/1/1</id><title>Comment #1</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-1" /><content type="html">&lt;p&gt;First&lt;/p&gt;</content></entry></feed>""")
+        # Since ElementTree.SubElement.attrib is a dict, it can be emitted in any order. Normalize:
+        data = data.replace(
+            'ref="tag:example.org,2018:/isso/1/1" href="https://example.org/path/#isso-1"',
+            'href="https://example.org/path/#isso-1" ref="tag:example.org,2018:/isso/1/1"',
+            1  # count
+        )
+        expected_data = """<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"><updated>2018-04-01T10:00:00Z</updated><id>tag:example.org,2018:/isso/thread/path/</id><title>Comments for example.org/path/</title><entry><id>tag:example.org,2018:/isso/1/2</id><title>Comment #2</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-2" /><content type="html">&lt;p&gt;&lt;em&gt;Second&lt;/em&gt;&lt;/p&gt;</content><thr:in-reply-to href="https://example.org/path/#isso-1" ref="tag:example.org,2018:/isso/1/1" /></entry><entry><id>tag:example.org,2018:/isso/1/1</id><title>Comment #1</title><updated>2018-04-01T10:00:00Z</updated><author><name /></author><link href="https://example.org/path/#isso-1" /><content type="html">&lt;p&gt;First&lt;/p&gt;</content></entry></feed>"""
+        self.assertEqual(data, expected_data)
 
     def testCounts(self):
 

--- a/isso/tests/test_html.py
+++ b/isso/tests/test_html.py
@@ -89,6 +89,7 @@ class TestHTML(unittest.TestCase):
         conf = config.new({
             "markup": {
                 "options": "autolink",
+                "flags": "",
                 "allowed-elements": "",
                 "allowed-attributes": ""
             }

--- a/isso/utils/html.py
+++ b/isso/utils/html.py
@@ -5,6 +5,11 @@ from __future__ import unicode_literals
 import bleach
 import misaka
 
+try:
+    from backports.configparser import NoOptionError
+except ImportError:
+    from configparser import NoOptionError
+
 
 class Sanitizer(object):
 
@@ -49,9 +54,9 @@ class Sanitizer(object):
 
 
 def Markdown(extensions=("strikethrough", "superscript", "autolink",
-                         "fenced-code")):
+                         "fenced-code"), flags=[]):
 
-    renderer = Unofficial()
+    renderer = Unofficial(flags=flags)
     md = misaka.Markdown(renderer, extensions=extensions)
 
     def inner(text):
@@ -80,7 +85,11 @@ class Markup(object):
 
     def __init__(self, conf):
 
-        parser = Markdown(conf.getlist("options"))
+        try:
+            conf_flags = conf.getlist("flags")
+        except NoOptionError:
+            conf_flags = []
+        parser = Markdown(extensions=conf.getlist("options"), flags=conf_flags)
         sanitizer = Sanitizer(
             conf.getlist("allowed-elements"),
             conf.getlist("allowed-attributes"))

--- a/share/isso-dev.conf
+++ b/share/isso-dev.conf
@@ -28,6 +28,7 @@ enabled = false
 
 [markup]
 options = strikethrough, autolink, fenced_code, no_intra_emphasis
+flags =
 allowed-elements =
 allowed-attributes =
 

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -181,6 +181,11 @@ require-email = false
 # there, separated by comma.
 options = strikethrough, autolink, fenced_code, no_intra_emphasis
 
+# Misaka-specific HTML rendering flags, all html rendering flags can be used
+# here, separated by comma, either by their name or as HTML_<flag>.
+# Per Misaka's defaults, no flags are set.
+flags =
+
 # Additional HTML tags to allow in the generated output, comma-separated. By
 # default, only a, blockquote, br, code, del, em, h1, h2, h3, h4, h5, h6, hr,
 # ins, li, ol, p, pre, strong, table, tbody, td, th, thead and ul are allowed.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py34,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
New `flags` option in the `[markdown]` section to customize Misaka's Markdown HTML rendering.

By default, no flags are set.

```
[markup]
flags = skip-html, escape, hard-wrap
```

Update `CHANGES.rst` and add the section to the sample `isso.conf` and `isso-dev.conf`.

---

Also fix flaky tests and update to python 3.8.