### PR TITLE
Feature : filtering comments based on URI of their pages

### DIFF
--- a/About-URI-filtering.md
+++ b/About-URI-filtering.md
@@ -1,0 +1,3 @@
+# About URI filtering
+
+This feature causes *Isso* to accept or reject comments based on URI of a page a new comment is supposed to belong to. This is done by mentioning a pattern in `[guard]` section of the server config file. 

--- a/About-URI-filtering.md
+++ b/About-URI-filtering.md
@@ -1,3 +1,36 @@
 # About URI filtering
 
-This feature causes *Isso* to accept or reject comments based on URI of a page a new comment is supposed to belong to. This is done by mentioning a pattern in `[guard]` section of the server config file. 
+This feature causes *Isso* to accept or reject comments based on URI of a page a new comment is supposed to belong to. This is done by mentioning a pattern in `[guard]` section of the server config file in a field named `uri-filter`. You should set an unqueted [Python regex](https://docs.python.org/3/library/re.html) string.
+
+## Examples
+
+* To accept comments for a single page under `/path/to/index.html` and reject others, use:
+```ini
+[guard]
+enabled = true
+uri-filter = /path/to/index\.html
+```
+
+* Use this config to accept comments for a page under `/path/to/article/`, which also can be retreived under `/path/to/article/index.html`:
+
+```
+[guard]
+enabled = true
+uri-filter = /path/to/article/(index\.html)?
+``` 
+
+* To accept URI's only with common path `/articles/` or `/news/`, use this:
+
+```ini
+[guard]
+enabled = true
+uri-filter = /(articles|news)/.+
+```
+
+* This configuration causes isso to accept comments for `/posts/2019-01-01/*` through `/posts/2019-12-30/*` and reject anything else:
+
+```ini
+[guard]
+enabled = true
+uri-filter = /posts/2019-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|30|31)/.+
+```

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -113,6 +113,7 @@ class Isso(object):
 
         views.Info(self)
         comments.API(self, self.hasher)
+        logger.info("Isso started up")
 
     def render(self, text):
         return self.markup.render(text)

--- a/isso/db/__init__.py
+++ b/isso/db/__init__.py
@@ -13,7 +13,7 @@ from isso.compat import buffer
 
 from isso.db.comments import Comments
 from isso.db.threads import Threads
-from isso.db.spam import Guard
+from isso.db.spam import StatefulGuard
 from isso.db.preferences import Preferences
 
 
@@ -39,7 +39,7 @@ class SQLite3:
         self.preferences = Preferences(self)
         self.threads = Threads(self)
         self.comments = Comments(self)
-        self.guard = Guard(self)
+        self.guard = StatefulGuard(self)
 
         if rv is None:
             self.execute("PRAGMA user_version = %i" % SQLite3.MAX_VERSION)

--- a/isso/db/spam.py
+++ b/isso/db/spam.py
@@ -2,9 +2,8 @@
 
 import time
 
-
-class Guard:
-
+# A guard which uses database
+class StatefulGuard:
     def __init__(self, db):
 
         self.db = db
@@ -16,10 +15,9 @@ class Guard:
         if not self.conf.getboolean("enabled"):
             return True, ""
 
-        for func in (self._limit, self._spam):
-            valid, reason = func(uri, comment)
-            if not valid:
-                return False, reason
+        valid, reason = self._limit(uri, comment)
+        if not valid:
+        	return False, reason
         return True, ""
 
     @classmethod
@@ -62,15 +60,4 @@ class Guard:
             if len(rv) > 0:
                 return False, "edit time frame is still open"
 
-        # require email if :param:`require-email` is enabled
-        if self.conf.getboolean("require-email") and not comment.get("email"):
-            return False, "email address required but not provided"
-
-        # require author if :param:`require-author` is enabled
-        if self.conf.getboolean("require-author") and not comment.get("author"):
-            return False, "author address required but not provided"
-
-        return True, ""
-
-    def _spam(self, uri, comment):
         return True, ""

--- a/isso/guardian/__init__.py
+++ b/isso/guardian/__init__.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+
+# A guard without any reference to the database
+class StatelessGuard:
+	def __init__(self, config):
+		self.conf = config
+	
+	def validate(self, uri, comment):
+		if not self.conf.getboolean("enabled"):
+			return True, ""
+		return self._requiredFields(comment)
+	
+	def _requiredFields(self, comment):
+		"""Checks required fields.
+		@param comment : A JSON object
+		@return True,empty string if everything is OK; else False and a reason"""
+		# require email if :param:`require-email` is enabled
+		if self.conf.getboolean("require-email") and not comment.get("email"):
+			return False, "email address required but not provided"
+
+		# require author if :param:`require-author` is enabled
+		if self.conf.getboolean("require-author") and not comment.get("author"):
+			return False, "author address required but not provided"
+		
+		return True,""
+	

--- a/isso/tests/test_guard.py
+++ b/isso/tests/test_guard.py
@@ -6,6 +6,7 @@ import unittest
 import os
 import json
 import tempfile
+import random
 
 from werkzeug import __version__
 from werkzeug.test import Client
@@ -32,7 +33,8 @@ class TestGuard(unittest.TestCase):
         self.path = tempfile.NamedTemporaryFile().name
 
     def makeClient(self, ip, ratelimit=2, direct_reply=3, self_reply=False,
-                   require_email=False, require_author=False):
+                   require_email=False, require_author=False,
+                   uri_filter=None):
 
         conf = config.load(os.path.join(dist.location, "share", "isso.conf"))
         conf.set("general", "dbpath", self.path)
@@ -43,6 +45,7 @@ class TestGuard(unittest.TestCase):
         conf.set("guard", "reply-to-self", "1" if self_reply else "0")
         conf.set("guard", "require-email", "1" if require_email else "0")
         conf.set("guard", "require-author", "1" if require_author else "0")
+        conf.set("guard", "uri-filter", str(uri_filter) if uri_filter else None)
 
         class App(Isso, core.Mixin):
             pass
@@ -165,3 +168,79 @@ class TestGuard(unittest.TestCase):
             "/new?uri=test", data=payload("")).status_code, 403)
         self.assertEqual(client_strict.post(
             "/new?uri=test", data=payload("pipo author")).status_code, 201)
+            
+    def testURIFilter(self) :
+        client = self.makeClient("127.0.0.1", ratelimit=10)
+        client_strict = self.makeClient("127.0.0.2", ratelimit=10, uri_filter="/(articles|news)/.+")
+        
+        # Without any filter
+        self.assertEqual(client.post(
+            "/new?uri=test", data=self.data).status_code, 201)
+        self.assertEqual(client.post(
+            "/new?uri=/articles/awesome-article", data=self.data).status_code, 201)
+        self.assertEqual(client.post(
+            "/new?uri=/news/some-topic", data=self.data).status_code, 201)
+        
+        # With a URI filter in place, it must accept matched URI's only
+        self.assertEqual(client_strict.post(
+            "/new?uri=test", data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post(
+            "/new?uri=/articles/awesome-article", data=self.data).status_code, 201)
+        self.assertEqual(client_strict.post(
+            "/new?uri=/news/some-topic", data=self.data).status_code, 201)
+        self.assertEqual(client_strict.post(
+            "/new?uri=/ARTICLES/awesome-article", data=self.data).status_code, 201)
+        self.assertEqual(client_strict.post(
+            "/new?uri=/NEWS/some-topic", data=self.data).status_code, 201)
+        
+        client_strict = self.makeClient("127.0.0.2", ratelimit=10, uri_filter=r"/path/to/article/(index\.html)?")
+        self.assertEqual(client_strict.post("/new?uri=test", 
+        	data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/path", 
+        	data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/path/to", 
+        	data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/path/to/article", 
+        	data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/path/to/article/crap", 
+        	data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/path/to/article/indexXhtml", 
+        	data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/path/to/article/", 
+        	data=self.data).status_code, 201)
+        self.assertEqual(client_strict.post("/new?uri=/path/to/article/index.html", 
+        	data=self.data).status_code, 201)
+        
+        # Posts in range of year 2019
+        somedata = json.dumps({"text": "Lorem ipsum.", "title":"Not important"})
+        client_strict = self.makeClient("127.0.0.2", ratelimit=700, 
+        	uri_filter=r"/posts/2019-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|30|31)/.+")
+        
+        
+        self.assertEqual(client_strict.post("/new?uri=/posts/2018-01-02/anything",	
+        data=somedata).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/2020-01-02/anything",
+        			data=somedata).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/2019-00-02/anything",
+        			data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/2019-13-02/anything",
+        			data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/2019-01-00/anything",
+        			data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/2019-01-32/anything",
+        			data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/2019-01-02",
+        			data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/nowhere",
+        			data=self.data).status_code, 403)
+        self.assertEqual(client_strict.post("/new?uri=/posts/.+",
+        			data=self.data).status_code, 403)
+        	
+        for month in range(1,13):
+        	for day in range(1,32) :
+        		uri = "/new?uri=/posts/2019-%02d-%02d/%x" % (month,day,random.randrange(999999999))
+        		print("Testing valid uri : %s" % uri)
+        		response = client_strict.post(uri, data=self.data)
+        		if (response.status_code>=400) :
+        			print(response.get_data(as_text=True))
+        		self.assertEqual(response.status_code, 201)

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -176,6 +176,9 @@ require-author = false
 # done on the provided address). Do not forget to configure the client.
 require-email = false
 
+# A Regex pattern to be matched against incoming URI's. If this field is 
+# specified then isso will accept matched URI's only
+uri-filter = 
 
 [markup]
 # Customize markup and sanitized HTML. Currently, only Markdown (via Misaka) is


### PR DESCRIPTION
Site managers have an option to set a filter for acceptable URI's. You need to put a Regex pattern as new field `uri-filter` under section `[guard]`