### PR TITLE
Fixing likes counter of replies not being displayed

### DIFF
--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -152,7 +152,7 @@
 .isso-comment .isso-postbox {
     margin-top: 0.8em;
 }
-.isso-comment.isso-no-votes span.votes {
+.isso-comment.isso-no-votes > * > .isso-comment-footer span.votes {
     display: none;
 }
 


### PR DESCRIPTION
Until this fix, likes counters of replies are only displayed if the parent comment has likes.

This is because the previous CSS rule there applied to **all** HTML children of the element with the `isso-no-votes` class, not only its own footer likes ounter.
With this PR we get the expected behaviour