### PR TITLE
Handle browsers with no navigator.language better (#521)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,14 +8,24 @@ Changelog for Isso
 
 - Don't ignore missing configuration files.
   (Jelmer Vernooĳ)
+
 - Serve isso.css separately to avoid `style-src: unsafe-inline` CSP and allow
   clients to override fetch location (#704, ix5):
-
     data-isso-css-url="https://comments.example.org/css/isso.css"
+
 - New "samesite" option in [server] section to override SameSite header for
   cookies. (#700, ix5)
+
 - Fallback for SameSite header depending on whether host is served over https
   or http (#700, ix5)
+
+- Improved detection of browser-supplied language preferences (#521)
+  Isso will now honor the newer `navigator.languages` global property
+  as well as `navigator.language` and `navigator.userLanguage`.
+  There is a new configuration property `data-isso-default-lang`
+  that specifies the language to use (instead of English) when none
+  of these is available.  (The existing `data-isso-lang` *overrides*
+  browser-supplied language preferences.)
 
 0.12.4 (2021-02-03)
 -------------------

--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -121,12 +121,32 @@ Defaults to `true`.
 data-isso-lang
 --------------
 
-Override useragent's preferred language. Isso has been translated in over 12
-languages. The language is configured by its `ISO 639-1
-<https://en.wikipedia.org/wiki/ISO_639-1>`_ (two letter) code.
+Always render the Isso UI in this language, ignoring what the
+user-agent says is the preferred language.  The default is to
+honor the user-agent's preferred language, and this can be
+specified explicitly by using ``data-isso-lang=""``.
 
-You find a list of all supported languages on `GitHub
-<https://github.com/posativ/isso/tree/master/isso/js/app/i18n>`_.
+The value of this property should be a `BCP 47 language tag
+<https://tools.ietf.org/html/bcp47>`_, such as "en", "ru", or "pt-BR".
+Language tags are processed case-insensitively, and may use
+underscores as separators instead of dashes (e.g. "pt_br" is treated
+the same as same as "pt-BR").
+
+You can find a list of all supported languages by browsing the
+`i18n directory
+<https://github.com/posativ/isso/tree/master/isso/js/app/i18n>`_ of
+the source tree.
+
+data-isso-default-lang
+----------------------
+
+Render the Isso UI in this language when the user-agent does not
+specify a preferred language, or if the language it specifies is not
+supported.  Like ``data-isso-lang``, the value of this property should
+be a BCP 47 language tag.  Defaults to "en".
+
+If you specify both ``data-isso-default-lang`` and ``data-isso-lang``,
+``data-isso-lang`` takes precedence.
 
 data-isso-reply-to-self
 -----------------------

--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -165,7 +165,7 @@ define(["app/dom", "app/utils", "app/config", "app/api", "app/jade", "app/i18n",
 
         // update datetime every 60 seconds
         var refresh = function() {
-            $(".permalink > time", el).textContent = utils.ago(
+            $(".permalink > time", el).textContent = i18n.ago(
                 globals.offset.localTime(), new Date(parseInt(comment.created, 10) * 1000));
             setTimeout(refresh, 60*1000);
         };


### PR DESCRIPTION
The code for setting `config["lang"]`, in `isso/app/config.js`,
assumes that browsers will always provide a value for
`navigator.language` and/or `navigator.userLanguage`.  Per bug #521,
this is not a safe assumption.

While I was attempting to fix this, I noticed that regional variants
of a language (`zh-TW`, `pt-BR`) were being handled in an ad-hoc,
unreliable manner.  I also noticed a new user-agent language property
[`navigator.languages`][] which more closely matches the semantics of
[`Accept-Language`][]—it would be good to support that.

This patch addresses all the above problems, as follows:

1. Add a new configuration property `data-isso-default-lang` that
   specifies the language to use (instead of English) when the browser
   *doesn’t* have a preference.

2. Document that we expect the value of `data-isso-lang` and
   `data-isso-default-lang` to be a [BCP 47][] language tag, because
   this is what `navigator.language` etc contain.  (The practical
   upshot is that tags like `zh-TW` are officially allowed now.)

3. In `config.js`, compile an array of candidate language tags, in
   descending order of preference, from all available sources:
   `data-isso-lang`, `navigator.languages`, `navigator.language`,
   `navigator.userLanguage`, `data-isso-default-lang`, and finally
   `"en"` as a backstop.  Handle any or all of the above being
   null/undefined/empty.  This array goes into `config["langs"]`.
   `config["lang"]` is removed.

4. In `i18n.js`, select the first entry in `config["langs"]` for which
   we have both pluralforms and a translation, and make that the value
   of `i18n.lang`.  An English backstop is supplied here too for extra
   defensiveness.  Also, if we don’t have a translation for say
   `zh-HK`, try `zh` before moving on to the next entry in the array.

5. New function `utils.normalize_bcp47` ensures that we process
   language tags, whereever they came from, case-insensitively and
   treating `_` as equivalent to `-`.

6. Move `utils.ago` to `i18n.ago` to avoid a circular dependency
   between utils and i18n.

[`navigator.languages`]: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages
[`Accept-Language`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
[BCP 47]: https://tools.ietf.org/html/bcp47