### PR TITLE
Require an edit cookie to be able to view a comment to be edited.

### DIFF
--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -231,6 +231,17 @@ class TestComments(unittest.TestCase):
         self.assertEqual(loads(r.data), None)
         self.assertEqual(self.get('/id/1').status_code, 404)
 
+    def testFetchAuthorization(self):
+        self.post('/new?uri=%2Fpath%2F',
+                  data=json.dumps({'text': 'Lorem ipsum ...'}))
+
+        r = self.get('/id/1?plain=1')
+        self.assertEqual(r.status_code, 200)
+
+        self.client.delete_cookie('localhost.local', '1')
+        r = self.get('/id/1?plain=1')
+        self.assertEqual(r.status_code, 403)
+
     def testDeleteWithReference(self):
 
         client = JSONClient(self.app, Response)

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -368,13 +368,15 @@ class API(object):
     """
     @api {get} /id/:id view
     @apiGroup Comment
+    @apiDescription
+        View an existing comment, for the purpose of editing. Editing a comment is only possible for a short period of time after it was created and only if the requestor has a valid cookie for it. See the [isso server documentation](https://posativ.org/isso/docs/configuration/server) for details.
 
     @apiParam {number} id
         The id of the comment to view.
     @apiUse plainParam
 
     @apiExample {curl} View the comment with id 4:
-        curl 'https://comments.example.com/id/4'
+        curl 'https://comments.example.com/id/4' -b cookie.txt
 
     @apiUse commentResponse
 
@@ -398,6 +400,11 @@ class API(object):
         rv = self.comments.get(id)
         if rv is None:
             raise NotFound
+
+        try:
+            self.isso.unsign(request.cookies.get(str(id), ''))
+        except (SignatureExpired, BadSignature):
+            raise Forbidden
 
         for key in set(rv.keys()) - API.FIELDS:
             rv.pop(key)


### PR DESCRIPTION
The `/id` GET endpoint is only used to retrieve the raw text of a comment to be edited. Being able to arbitrarily retrieve *any* comment through this endpoint is a potential privacy issue, since it allows a malicious actor to individually retrieve all comments from a website without knowledge of an existing thread URI.

This change requires that comment text retrieval has a valid edit cookie.

Fixes #679