### PR TITLE
[docs] Improve docs, cleanup, align with current version

### DIFF
--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -301,6 +301,11 @@ main {
       font-family: Monaco, Menlo, Consolas, monospace;
     }
 
+    code {
+      background-color: #eeeeee;
+      padding: 0.2em 0.3em;
+    }
+
     .highlight {
       margin: 1.2em 0;
       padding: 10px 15px;

--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -41,6 +41,51 @@ english translation of the ``postbox-notification`` message, you could add:
 
 .. __: https://github.com/posativ/isso/blob/master/isso/js/app/i18n/en.js
 
+Lazy-loading on scroll
+----------------------
+
+You can defer loading the ``embed.min.js`` script until the user has scrolled
+to the bottom of the page:
+
+.. code-block:: html
+
+    <script type="text/javascript">
+        // Lazy-load isso only when page end is in view
+        function loadIsso() {
+            var script = document.createElement("script");
+            script.setAttribute("type", "text/javascript");
+            script.setAttribute("src", "/prefix/js/embed.min.js");
+            // add relevant data-isso attributes here
+            script.setAttribute("data-isso", "/prefix/");
+            document.getElementsByTagName("head")[0].appendChild(script);
+        }
+        let offset = 50; // Start loading 50px before reaching bottom
+        function scrollBottomListener(ev) {
+            if ((window.scrollY + window.innerHeight)
+                    >= (document.documentElement.scrollHeight - offset)) {
+                loadIsso();
+                window.removeEventListener('scroll', scrollBottomListener);
+            }
+        }
+        window.onload = function() {
+          // If viewport >= page height, load immediately
+          if ((window.scrollY + window.innerHeight)
+                    >= (document.documentElement.scrollHeight - offset)) {
+              loadIsso();
+          } else {
+              window.addEventListener('scroll', scrollBottomListener);
+          }
+        }
+    </script>
+
+*Note that loading additional content only after user interaction is bad for
+SEO. Additionally, users could experience a "jank" effect.*
+
+Use lazy-loading only if you are desperately trying to save bandwidth. By
+specifying ``async`` in the ``<script`` tag, loading the Isso Javascript will
+not render-block anyway.
+
+
 data-isso
 ---------
 

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -29,9 +29,10 @@ Sections covered in this document:
 .. contents::
     :local:
 
-
 General
 -------
+
+.. _configure-general:
 
 In this section, you configure most comment-related options such as database path,
 session key and hostname. Here are the default values for this section:
@@ -111,13 +112,15 @@ gravatar-url
     Defaults to "https://www.gravatar.com/avatar/{}?d=identicon"
 
 latest-enabled
-    If True it will enable the ``/latest`` endpoint. Optional, defaults 
+    If True it will enable the ``/latest`` endpoint. Optional, defaults
     to False.
 
 
 
 .. _CORS: https://developer.mozilla.org/en/docs/HTTP/Access_control_CORS
 
+
+.. _configure-moderation:
 
 Moderation
 ----------
@@ -146,6 +149,8 @@ approve-if-email-previously-approved
 purge-after
     remove unprocessed comments in moderation queue after given time.
 
+
+.. _configure-server-block:
 
 Server
 ------
@@ -295,6 +300,8 @@ require-email
 
     Do not forget to configure the `client <client>`_ accordingly.
 
+.. _configure-markup:
+
 Markup
 ------
 
@@ -384,6 +391,8 @@ limit
 
 Admin
 -----
+
+.. _configure-admin:
 
 Isso has an optional web administration interface that can be used to moderate
 comments. The interface is available under ``/admin`` on your isso URL.

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -311,7 +311,7 @@ supported, but new languages are relatively easy to add.
 .. code-block:: ini
 
     [markup]
-    options = strikethrough, superscript, autolink
+    options = strikethrough, superscript, autolink, fenced-code
     flags = skip-html, escape, hard-wrap
     allowed-elements =
     allowed-attributes =
@@ -319,12 +319,14 @@ supported, but new languages are relatively easy to add.
 options
     `Misaka-specific Markdown extensions <https://misaka.61924.nl/#api>`_, all
     extension flags can be used there, separated by comma, either by their name
-    or as `EXT_`_.
+    or as ``EXT_``.
+
+    **Careful:** Misaka 1.0 used ``snake_case``, but 2.0 needs ``dashed-case``!
 
 flags
     `Misaka-specific HTML rendering flags
     <https://misaka.61924.nl/#html-render-flags>`_, all html rendering flags
-    can be used here, separated by comma, either by their name or as `HTML_`_.
+    can be used here, separated by comma, either by their name or as ``HTML_``.
     Per Misaka's defaults, no flags are set.
 
 allowed-elements

--- a/docs/docs/extras/api.rst
+++ b/docs/docs/extras/api.rst
@@ -89,10 +89,10 @@ Get the latest N comments for all threads:
 
     GET /latest?limit=N
 
-The N parameter limits how many of the latest comments to retrieve; it's 
+The N parameter limits how many of the latest comments to retrieve; it's
 mandatory, and must be an integer greater than 0.
 
-This endpoint needs to be enabled in the configuration (see the 
+This endpoint needs to be enabled in the configuration (see the
 ``latest-enabled`` option in the ``general`` section).
 
 
@@ -192,12 +192,12 @@ Counts all publicly visible comments for thread `uri`:
 
     GET /count?uri=%2Fhello-world%2F
     2
-    
+
 uri :
     URI to count comments for, required.
 
 returns an integer
-    
+
 Get Atom feed
 -------------
 
@@ -206,7 +206,7 @@ Get an Atom feed of comments for thread `uri`:
 .. code-block:: text
 
     GET /feed?uri=%2Fhello-world%2F
-    
+
 uri :
     URI to get comments for, required.
 

--- a/docs/docs/extras/deployment.rst
+++ b/docs/docs/extras/deployment.rst
@@ -237,7 +237,7 @@ Finally, copy'n'paste to `/var/www/isso.fcgi` (or whatever location you prefer):
     #!/usr/bin/env python
     #: uncomment if you're using a virtualenv
     # import sys
-    # sys.path.insert(0, '<your_local_path>/lib/python2.7/site-packages')
+    # sys.path.insert(0, '<your_local_path>/lib/python3.<ver>/site-packages')
 
     from isso import make_app, dist, config
     import os

--- a/docs/docs/index.rst
+++ b/docs/docs/index.rst
@@ -40,7 +40,12 @@ third-party. Just like IntenseDebate, livefrye etc. When you embed Disqus, they
 can do anything with your readers (and probably mine Bitcoins, see the loading
 times).
 
-Isso is not the first open-source commenting server:
+Isso is not the only open-source commenting server:
+
+* `commento <https://commento.io/>`_, written in Go. Requires a
+  `postgresql <https://www.postgresql.org/>`_ database.
+
+* `Remark42 <https://remark42.com/docs/1.6/>`_, written in Go.
 
 * `talkatv <https://github.com/talkatv/talkatv>`_, written in Python.
   Unfortunately, talkatv's (read "talkative") development stalled. Neither

--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -164,7 +164,7 @@ Install from Source
 If you want to hack on Isso or track down issues, there's an alternate
 way to set up Isso. It requires a lot more dependencies and effort:
 
-- Python 2.7 or 3.4+ (+ devel headers)
+- Python 3.4+ (+ devel headers)
 - Virtualenv
 - SQLite 3.3.8 or later
 - a working C compiler

--- a/docs/docs/troubleshooting.rst
+++ b/docs/docs/troubleshooting.rst
@@ -18,6 +18,14 @@ Install Isso in a virtual environment as described in
 :ref:`install-interludium`. Alternatively, you can use `pip install --user`
 to install Isso into the user's home.
 
+Why isn't markdown in my comments rendering as I expect?
+--------------------------------------------------------
+
+Please configure Isso's markup parser to your requirements as described in
+:ref:`configure-markup`. As of version 0.12.2, Isso uses misaka 2.0 to render
+markdown. Misaka 2.0 uses ``dashed-case`` instead of ``snake_case`` for
+options, you might have to update your config.
+
 UnicodeDecodeError: 'ascii' codec can't decode byte 0xff
 --------------------------------------------------------
 

--- a/docs/docs/troubleshooting.rst
+++ b/docs/docs/troubleshooting.rst
@@ -36,4 +36,7 @@ parse configuration file with non-ascii characters and so forth).
 The web console shows 404 Not Found responses
 ---------------------------------------------
 
-That's fine. Isso returns "404 Not Found" to indicate "No comments".
+Isso returned "404 Not Found" to indicate "No comments" in versions prior to
+0.12.3. This behaviour was changed in
+`a pull request <https://github.com/posativ/isso/pull/565>`_ to return a code
+of "200" with an empty array.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -7,11 +7,9 @@ Why SQLite3?
 Although partially answered on the index page, here is a more complete answer: If
 you manage massive amounts of comments, Isso is a really bad choice. Isso is
 designed to be simple and easy to setup, it is not optimized for high-traffic
-websites (use a `dedicated Disqus`_ instance then).
+websites.
 
     Comments are not big data.
 
-For example, if you have 209 threads and 778 comments in total this only needs 620 kilobytes 
+For example, if you have 209 threads and 778 comments in total this only needs 620 kilobytes
 of memory. This is an excellent use case for SQLite.
-
-.. _dedicated Disqus:

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
         </li>
         <li>
             <p><strong>Configurable JS client</strong></p>
-            <p>Embed a single JS file, 40kb (12kb gzipped) and you are
+            <p>Embed a single JS file, 65kB (20kB gzipped) and you are
                done.</p>
             <p>Supports Firefox, Safari, Chrome and IE10.</p>
         </li>

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -1,7 +1,7 @@
 Releasing steps
 ===============
 
-* Run ``python3 setup.py nosetests``, ``python2 setup.py nosetests``
+* Run ``python3 setup.py nosetests``
 * Update version number in ``setup.py`` and ``CHANGES.rst``
 * ``git commit -m "Preparing ${VERSION}" setup.py CHANGES.rst``
 * ``git tag -as ${VERSION}``


### PR DESCRIPTION
Numerous improvements to docs, fix some mistakes cleanups, align with current Isso behaviour .

- index: Correct Isso's current size
- Clean up whitespace, add links to sections
- Remove py2 references
- troubleshooting: Correct 404 section
  Isso returns 200 instead of 404 since https://github.com/posativ/isso/pull/565
- docs/index: [Mention more alternatives](https://164-203644882-gh.circle-artifacts.com/0/docs-html/docs/index.html#what-s-wrong-with-disqus)
  Rising tide lifts all ships and such...
- troubleshooting: [Mention markup config](https://164-203644882-gh.circle-artifacts.com/0/docs-html/docs/troubleshooting/index.html#why-isn-t-markdown-in-my-comments-rendering-as-i-expect)
  This question has popped up in https://github.com/posativ/isso/issues/677
- faq: Cleanup - remove empty link
- server: Clarify misaka in markup section
  - Add note about misaka 1.0/2.0 discrepancy.
  - Align example `[markup]` conf block inside docs with the   defaults in `util/html.py`.
  - Fix formatting issue, code instead of link.
- client: [Document lazy-loading](https://164-203644882-gh.circle-artifacts.com/0/docs-html/docs/configuration/client/index.html#lazy-loading-on-scroll)

**EDIT:** Added links to live versions.