### PR TITLE
share: isso.conf: Use dashed-case for misaka 2.0

### DIFF
--- a/share/isso.conf
+++ b/share/isso.conf
@@ -188,9 +188,10 @@ require-email = false
 # Customize markup and sanitized HTML. Currently, only Markdown (via Misaka) is
 # supported, but new languages are relatively easy to add.
 
-# Misaka-specific Markdown extensions, all flags starting with EXT_ can be used
-# there, separated by comma.
-options = strikethrough, autolink, fenced_code, no_intra_emphasis
+# Misaka-specific Markdown extensions, all extensions can be used here,
+# separated by comma, either by their name or by EXT_<extension>.
+# Careful: Misaka 1.0 used "snake_case", but 2.0 needs "dashed-case"!
+options = strikethrough, superscript, autolink, fenced-code
 
 # Misaka-specific HTML rendering flags, all html rendering flags can be used
 # here, separated by comma, either by their name or as HTML_<flag>.


### PR DESCRIPTION
Misaka expects extensions and flags in `dashed-case` instead of the legacy `snake_case` as of version 2.0.

See https://github.com/FSX/misaka/blob/v2.1.1/misaka/utils.py#L15-L37

Also align "options" values with the defaults in `utils/html.py`.