### PR TITLE
utils: html: Normalize misaka extensions

### DIFF
--- a/isso/tests/test_html.py
+++ b/isso/tests/test_html.py
@@ -99,6 +99,23 @@ class TestHTML(unittest.TestCase):
                       ['<p><a href="http://example.org/" rel="nofollow noopener">http://example.org/</a> and sms:+1234567890</p>',
                        '<p><a rel="nofollow noopener" href="http://example.org/">http://example.org/</a> and sms:+1234567890</p>'])
 
+    def test_sanitized_render_extensions(self):
+        """Options should be normalized from both dashed-case or snake_case (legacy)"""
+        conf = config.new({
+            "markup": {
+                "options": "no_intra_emphasis",  # Deliberately snake_case
+                "flags": "",
+                "allowed-elements": "",
+                "allowed-attributes": ""
+            }
+        })
+        renderer = html.Markup(conf.section("markup")).render
+        self.assertEqual(renderer("foo_bar_baz"), '<p>foo_bar_baz</p>')
+
+        conf.set("markup", "options", "no-intra-emphasis")  # dashed-case
+        renderer = html.Markup(conf.section("markup")).render
+        self.assertEqual(renderer("foo_bar_baz"), '<p>foo_bar_baz</p>')
+
     def test_code_blocks(self):
         convert = html.Markdown(extensions=('fenced-code',))
         examples = [

--- a/isso/utils/html.py
+++ b/isso/utils/html.py
@@ -54,6 +54,10 @@ class Sanitizer(object):
 def Markdown(extensions=("strikethrough", "superscript", "autolink",
                          "fenced-code"), flags=[]):
 
+    # Normalize render extensions for misaka 2.0, which uses `dashed-case`
+    # instead of `snake_case` (misaka 1.x) for options.
+    extensions = [x.replace("_", "-") for x in extensions]
+
     renderer = Unofficial(flags=flags)
     md = misaka.Markdown(renderer, extensions=extensions)
 


### PR DESCRIPTION
As of version 0.12.2, Isso uses misaka 2.0 to render markdown. Misaka 2.0 uses `dashed-case` instead of `snake_case` for options.

Normalize passed extensions to dashed-case to avoid mistakes.

Note: Flags have only been around in Isso with misaka 2.0, so I hope users did not use dashed case with them.