### PR TITLE
[docs] Add 'Testing' section

### DIFF
--- a/docs/_isso/sidebar-docs.html
+++ b/docs/_isso/sidebar-docs.html
@@ -27,6 +27,7 @@
 <ul>
     {{ doc("docs/extras/deployment", "Deployment") }}
     {{ doc("docs/extras/advanced-integration", "Advanced Integration") }}
+    {{ doc("docs/extras/testing", "Testing") }}
     {{ doc("docs/extras/api", "API") }}
     {{ doc("docs/extras/contribs", "Community tools") }}
 </ul>

--- a/docs/docs/extras/testing.rst
+++ b/docs/docs/extras/testing.rst
@@ -1,0 +1,29 @@
+Testing
+-------
+
+Isso is tested by the `nose`_ tool. You should also install the `coverage`_
+module to receive code coverage statistics.
+
+.. code-block:: sh
+
+    $ pip install nose coverage
+
+Nose needs your Isso package to be installed as a site package to work, else it
+will complain with:
+
+.. code-block:: sh
+
+    pkg_resources.DistributionNotFound: The 'isso' distribution was not found and is required by the application
+
+When running Isso via ``nosetests``, you need to be aware that it will use the
+packaged version of Isso in your ``site-packages``, not the one you have in
+your current working directory.
+
+Use ``pip install -e .`` to install Isso as an "editable" package (the package
+in ``site-packages`` will be a symlink to your current development directory).
+
+You can run tests independently via ``nosetests [options] isso/`` or use Isso's
+standard test suite via ``make tests coverage``.
+
+.. _nose: https://nose.readthedocs.io/en/latest/
+.. _coverage: https://coverage.readthedocs.io/en/latest/


### PR DESCRIPTION
I ran into way too many `pkg_resources.DistributionNotFound` and `<parser>.NoSectionError` errors when trying to set up nosetests.
Prevent others from the same fate.

**EDIT:** Can be seen live using [this build artifact](https://156-203644882-gh.circle-artifacts.com/0/docs-html/docs/extras/testing/index.html)