### PR TITLE
Swap node-sass for sassc, mention in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-# INSTALLATION: pip install sphinx && npm install --global node-sass
+# INSTALLATION:
+# pip install sphinx
+# npm install -g requirejs uglify-js jade
+# apt install sassc
 
 ISSO_JS_SRC := $(shell find isso/js/app -type f) \
 	       $(shell ls isso/js/*.js | grep -vE "(min|dev)") \
@@ -29,7 +32,7 @@ DOCS_HTML_DST := docs/_build/html
 
 RJS = r.js
 
-SASS = node-sass
+SASS = sassc
 
 all: man js site
 
@@ -54,7 +57,7 @@ man: $(DOCS_RST_SRC)
 	mv man/isso.conf.5 man/man5/isso.conf.5
 
 ${DOCS_CSS_DST}: $(DOCS_CSS_SRC) $(DOCS_CSS_DEP)
-	$(SASS) --no-cache $(DOCS_CSS_SRC) $@
+	$(SASS) $(DOCS_CSS_SRC) $@
 
 ${DOCS_HTML_DST}: $(DOCS_RST_SRC) $(DOCS_CSS_DST)
 	sphinx-build -b dirhtml docs/ $@

--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -168,7 +168,9 @@ way to set up Isso. It requires a lot more dependencies and effort:
 - Virtualenv
 - SQLite 3.3.8 or later
 - a working C compiler
-- Node.js, `NPM <https://npmjs.org/>`__ and `Bower <http://bower.io/>`__
+- Node.js, `NPM <https://npmjs.org/>`__ and `Bower <http://bower.io/>`__ - *for frontend*
+- `sassc <https://github.com/sass/sassc>`_ for compiling
+  `.scss <https://sass-lang.com/>`_ - *for docs*
 
 Get a fresh copy of Isso:
 
@@ -204,12 +206,18 @@ Integration without optimization:
     <script src="/js/config.js"></script>
     <script data-main="/js/embed" src="/js/components/requirejs/require.js"></script>
 
-Optimization:
+Optimization - generate ``embed.(min|dev).js``:
 
 .. code-block:: sh
 
     ~> npm install -g requirejs uglify-js jade
     ~> make js
+
+Generate docs:
+
+.. code-block:: sh
+
+    ~> make site
 
 .. _init-scripts:
 


### PR DESCRIPTION
People should not be forced to install nodejs & npm just to contribute to docs.
sassc produces virtually identical output to node-sass; with `precision` set to "5", the output is **identical**.

node-sass wastes a lot of space and pulls in a total of 195 (mostly untrusted!) packages.
```
$ du -hs --apparent-size ~/.npm/node-sass/ ~/.cache/node_modules/
3,3M	/home/user/.npm/node-sass/
15M	/home/user/.cache/node_modules/
```
`sassc` is a couple of kilobytes, including ~3MB for `libsass`.

`sassc` is also faster by a lot, which makes live-reloading much less annoying:

```
hyperfine 'sassc --precision 5 docs/_static/css/site.scss docs/_static/css/site.css'
Benchmark #1: sassc --precision 5 docs/_static/css/site.scss docs/_static/css/site.css
  Time (mean ± σ):      15.8 ms ±   2.4 ms    [User: 12.7 ms, System: 3.2 ms]
  Range (min … max):    14.8 ms …  35.6 ms    72 runs
```
```
hyperfine 'node-sass docs/_static/css/site.scss docs/_static/css/site.css'
Benchmark #1: node-sass docs/_static/css/site.scss docs/_static/css/site.css
  Time (mean ± σ):     200.4 ms ±   4.3 ms    [User: 181.6 ms, System: 49.6 ms]
  Range (min … max):   195.0 ms … 213.1 ms    13 runs
```

sassc is available for:
[Arch Linux](https://archlinux.org/packages/community/x86_64/sassc/)
[Ubuntu](https://packages.ubuntu.com/bionic/pysassc)
[Debian](https://packages.debian.org/stable/sassc)
[Fedora](https://src.fedoraproject.org/rpms/sassc)
[OpenSuse](https://software.opensuse.org/package/sassc)

Another benefit is that CI runs are very quick, since they no longer have to fetch all the nodejs-related packages and build `node-gyp`.
