### PR TITLE
fix: pt_PT file mispelled name + syntax error

### DIFF
--- a/isso/js/app/i18n/pt_PT.js
+++ b/isso/js/app/i18n/pt_PT.js
@@ -10,7 +10,7 @@ define({
 
     "num-comments": "Um Comentário\n{{ n }} Comentários",
     "no-comments": "Nenhum comentário ainda",
-    "atom-feed": "Feed Atom",European Portuguese
+    "atom-feed": "Feed Atom",
 
     "comment-reply": "Responder",
     "comment-edit": "Editar",


### PR DESCRIPTION
File missed the .js file extension.
The file contained a syntax error.