### PR TITLE
Only use npm for managing JS frontend build dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 /docs/_build
 /docs/_static/css/site.css
 
+node_modules/
+
 /pip-selfcheck.json
 
 # github/gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 FROM node:dubnium-buster AS jsBuilder
 WORKDIR /src/
 COPY . .
-RUN npm install -g requirejs uglify-js jade bower \
- && make init js
+RUN make init js
 
 # Second, create virtualenv
 FROM python:3.8-buster AS venvBuilder

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,14 @@ DOCS_MAN_DST := man/man1/isso.1 man/man5/isso.conf.5
 
 DOCS_HTML_DST := docs/_build/html
 
-RJS = r.js
+RJS = npx --no-install r.js
 
 SASS = node-sass
 
 all: man js site
 
 init:
-	(cd isso/js; bower --allow-root install almond requirejs requirejs-text jade)
+	npm install
 
 flakes:
 	flake8 . --count --max-line-length=127 --show-source --statistics

--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -168,7 +168,7 @@ way to set up Isso. It requires a lot more dependencies and effort:
 - Virtualenv
 - SQLite 3.3.8 or later
 - a working C compiler
-- Node.js, `NPM <https://npmjs.org/>`__ and `Bower <http://bower.io/>`__
+- Node.js, `NPM <https://npmjs.org/>`__
 
 Get a fresh copy of Isso:
 
@@ -197,18 +197,10 @@ Install JavaScript modules:
 
     ~> make init
 
-Integration without optimization:
-
-.. code-block:: html
-
-    <script src="/js/config.js"></script>
-    <script data-main="/js/embed" src="/js/components/requirejs/require.js"></script>
-
-Optimization:
+Build JavaScript frontend code:
 
 .. code-block:: sh
 
-    ~> npm install -g requirejs uglify-js jade
     ~> make js
 
 .. _init-scripts:

--- a/isso/js/.bowerrc
+++ b/isso/js/.bowerrc
@@ -1,1 +1,0 @@
-{"directory": "components/"}

--- a/isso/js/build.count.js
+++ b/isso/js/build.count.js
@@ -6,7 +6,7 @@
         "app/text/css": "app/text/dummy"
     },
 
-    name: "components/almond/almond",
+    name: "../../node_modules/almond/almond",
     include: ['count'],
     out: "count.min.js",
     wrap: true

--- a/isso/js/build.embed.js
+++ b/isso/js/build.embed.js
@@ -3,7 +3,7 @@
     mainConfigFile: 'config.js',
     stubModules: ['text', 'jade'],
 
-    name: "components/almond/almond",
+    name: "../../node_modules/almond/almond",
     include: ['embed'],
     out: "embed.min.js",
 

--- a/isso/js/config.js
+++ b/isso/js/config.js
@@ -1,9 +1,9 @@
 var requirejs = {
     paths: {
-        "text": "components/text/text",
+        "text": "../../node_modules/requirejs-text/text",
         "jade": "lib/requirejs-jade/jade",
-        "libjs-jade": "components/jade/jade",
-        "libjs-jade-runtime": "components/jade/runtime"
+        "libjs-jade": "../../node_modules/jade/jade",
+        "libjs-jade-runtime": "../../node_modules/jade/runtime"
     },
 
     config: {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "isso",
+  "author": "Martin Zimmermann",
+  "description": "lightweight Disquis alternative",
+  "license": "MIT",
+  "repository": "github:posativ/isso",
+  "dependencies": {},
+  "devDependencies": {
+    "almond": "^0.3.3",
+    "jade": "^1.5.0",
+    "requirejs-text": "^2.0.15",
+    "requirejs": "^2.3.6"
+  }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ universal=1
 
 [flake8]
 ignore = E501, E402
-exclude = docs/conf.py,.tox,.eggs
+exclude = docs/conf.py,node_modules,.tox,.eggs


### PR DESCRIPTION
Replace bower as well as global npm package installations in Dockerfile with a plain `package.json` that is used to configure what `npm install` will install. This avoids a dependency on bower which was deprecated in 2017 and hopefully makes it easier for others to build the JS frontend files.

There are lots of more things to cleanup in this area (jade got renamed to pug, requirejs could be replaced by webpack, just to name two outdated dependencies) so this is just a start.