### PR TITLE
Add missing commata to setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6"
-        "Programming Language :: Python :: 3.7"
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     install_requires=requires,
     setup_requires=["cffi>=1.3.0"],


### PR DESCRIPTION
Properly separate setup classifier strings by a comma, otherwise they
end up as a single string (can be observed in the output created by
`setup.py bdist_wheel`).