### PR TITLE
Build JavaScript files during python package build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 
+import os
+import setuptools.command.build_py
+import subprocess
+
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
             'werkzeug>=1.0', 'bleach', 'Flask-Caching>=1.9', 'Flask']
+
+
+class NpmBuildCommand(setuptools.command.build_py.build_py):
+    """Prefix Python build with node-based asset build"""
+
+    def run(self):
+        if 'TOX_ENV' not in os.environ:
+            subprocess.check_call(['make', 'init', 'js'])
+        setuptools.command.build_py.build_py.run(self)
+
 
 setup(
     name='isso',
@@ -34,5 +48,8 @@ setup(
     entry_points={
         'console_scripts':
             ['isso = isso:main'],
-    }
+    },
+    cmdclass={
+        'build_py': NpmBuildCommand,
+    },
 )


### PR DESCRIPTION
Make package builds via setuptools automatically trigger building of
merged & minified JS assets.

This fixes installing isso from source when using `pip install` as long
as both the python and node requirements are met. It also ensures that
`setup.py` commands like `build` or `bdist_wheel` create archives that
contain generated JS code.