### PR TITLE
Require Python >= 3.5

### DIFF
--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -164,7 +164,7 @@ Install from Source
 If you want to hack on Isso or track down issues, there's an alternate
 way to set up Isso. It requires a lot more dependencies and effort:
 
-- Python 3.4+ (+ devel headers)
+- Python 3.5+ (+ devel headers)
 - Virtualenv
 - SQLite 3.3.8 or later
 - a working C compiler

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
 
 if sys.version_info < (3, ):
     raise SystemExit("Python 2 is not supported.")
-elif (3, 0) <= sys.version_info < (3, 4):
-    raise SystemExit("Python 3 versions < 3.4 are not supported.")
+elif (3, 0) <= sys.version_info < (3, 5):
+    raise SystemExit("Python 3 versions < 3.5 are not supported.")
 
 setup(
     name='isso',


### PR DESCRIPTION
The minimum werkzeug version (1.0) requires Python 3 >= 3.5 so isso
has the same requirement too.

See also https://github.com/pallets/werkzeug/blob/dfde671ef969e27c7b14bd464688c009b34a7d2b/setup.py#L55 from werkzeug 1.0.0