### PR TITLE
Makefile, docs: Align with changes to npm handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # INSTALLATION:
 # pip install sphinx
-# npm install -g requirejs uglify-js jade
 # apt install sassc
+# make init
 
 ISSO_JS_SRC := $(shell find isso/js/app -type f) \
 	       $(shell ls isso/js/*.js | grep -vE "(min|dev)") \

--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -168,7 +168,7 @@ way to set up Isso. It requires a lot more dependencies and effort:
 - Virtualenv
 - SQLite 3.3.8 or later
 - a working C compiler
-- Node.js, `NPM <https://npmjs.org/>`__ and `Bower <http://bower.io/>`__ - *for frontend*
+- Node.js, `NPM <https://npmjs.org/>`__ - *for frontend*
 - `sassc <https://github.com/sass/sassc>`_ for compiling
   `.scss <https://sass-lang.com/>`_ - *for docs*
 
@@ -199,14 +199,7 @@ Install JavaScript modules:
 
     ~> make init
 
-Integration without optimization:
-
-.. code-block:: html
-
-    <script src="/js/config.js"></script>
-    <script data-main="/js/embed" src="/js/components/requirejs/require.js"></script>
-
-Optimization - generate ``embed.(min|dev).js``:
+Build JavaScript frontend code:
 
 .. code-block:: sh
 


### PR DESCRIPTION
Since https://github.com/posativ/isso/pull/695/ changed the way npm commands run, my docs updates in [#690](https://github.com/posativ/isso/pull/690/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R3) are outdated and should have been rebased.
Fix those.