### PR TITLE
Improve cookie SameSite/secure handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog for Isso
 
 - Don't ignore missing configuration files.
   (Jelmer Vernooĳ)
+- New "samesite" option in [server] section to override SameSite header for
+  cookies. (#700, ix5)
+- Fallback for SameSite header depending on whether host is served over https
+  or http (#700, ix5)
 
 0.12.4 (2021-02-03)
 -------------------

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -202,6 +202,17 @@ trusted-proxies
     `X-Forwarded-For` HTTP header, which is important for the mechanism
     forbiding several comment votes coming from the same subnet.
 
+samesite
+    override ``Set-Cookie`` header ``SameSite`` value.
+    Needed for setups where isso is not hosted on the same domain, e.g. called
+    from example.org and hosted under comments.example.org.
+    By default, isso will set ``SameSite=None`` when served over https and
+    ``SameSite=Lax`` when served over http
+    (see `MDM: SameSite <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite>`_
+    and `#682 <https://github.com/posativ/isso/issues/682>`_ for details).
+
+    Accepted values: ``None``, ``Lax``, ``Strict``
+
 .. _configure-smtp:
 
 SMTP

--- a/isso/tests/fixtures.py
+++ b/isso/tests/fixtures.py
@@ -16,6 +16,19 @@ class FakeIP(object):
         return self.app(environ, start_response)
 
 
+class FakeHost(object):
+
+    def __init__(self, app, host, scheme):
+        self.app = app
+        self.host = host
+        self.scheme = scheme
+
+    def __call__(self, environ, start_response):
+        environ['HTTP_HOST'] = self.host
+        environ['wsgi.url_scheme'] = self.scheme
+        return self.app(environ, start_response)
+
+
 class JSONClient(Client):
 
     def open(self, *args, **kwargs):

--- a/share/isso.conf
+++ b/share/isso.conf
@@ -119,6 +119,16 @@ profile = off
 # forbiding several comment votes coming from the same subnet.
 trusted-proxies =
 
+# Override Set-Cookie header SameSite value.
+# Needed for setups where isso is not hosted on the same domain, e.g. called
+# from example.org and hosted under comments.example.org.
+# By default, isso will set SameSite=None when served over https and
+# SameSite=Lax when served over http.
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+# and https://github.com/posativ/isso/issues/682
+# Accepted values: None, Lax, Strict
+samesite =
+
 
 [smtp]
 # Isso can notify you on new comments via SMTP. In the email notification, you


### PR DESCRIPTION
Add new `samesite` option in `[server]` section to configure `SameSite` header for cookies.

As a fallback, use `local.host` to detect URL scheme and set `SameSite` to `None` (https) or `Lax` (http) accordingly.

Set `Secure` attribute in response header so that cookies will only be sent when requesting content from `https://`
URLs.

Fixes:
```
Cookie “isso-[id]” will be soon rejected because it has the “SameSite” attribute set to “None”
```

(werkzeug sets `SameSite` to `None` by default anyway)

**NOTE:** This change _might_ break quite a few local test setups!

Discussion: https://github.com/posativ/isso/issues/682

See: https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
and https://werkzeug.palletsprojects.com/en/1.0.x/http/#werkzeug.http.dump_cookie

---

Sidenote:
- Setting `isso_host_script` should somehow be unified instead of duplicated in every function. `local.host` is only available per-request though, so there cannot be a class variable such as `self.isso_host_script`.