### PR TITLE
Remove legacy werkzeug support

### DIFF
--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -49,9 +49,6 @@ from os.path import dirname, join
 from argparse import ArgumentParser
 from functools import partial, reduce
 
-import pkg_resources
-werkzeug = pkg_resources.get_distribution("werkzeug")
-
 from itsdangerous import URLSafeTimedSerializer
 
 from werkzeug.routing import Map
@@ -212,9 +209,6 @@ def make_app(conf=None, threading=True, multiprocessing=False, uwsgi=False):
                            exposed=("X-Set-Cookie", "Date")))
 
     wrapper.extend([wsgi.SubURI, ProxyFixCustom])
-
-    if werkzeug.version.startswith("0.8"):
-        wrapper.append(wsgi.LegacyWerkzeugMiddleware)
 
     return reduce(lambda x, f: f(x), wrapper, isso)
 

--- a/isso/utils/__init__.py
+++ b/isso/utils/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import division, unicode_literals
 
-import pkg_resources
-werkzeug = pkg_resources.get_distribution("werkzeug")
-
 import hashlib
 import json
 import os
@@ -102,10 +99,6 @@ class Bloomfilter:
 
 
 class JSONRequest(Request):
-
-    if werkzeug.version.startswith("0.8"):
-        def get_data(self, **kw):
-            return self.data.decode('utf-8')
 
     def get_json(self):
         try:

--- a/isso/utils/hash.py
+++ b/isso/utils/hash.py
@@ -6,17 +6,7 @@ import codecs
 import hashlib
 
 
-try:
-    from werkzeug.security import pbkdf2_bin as pbkdf2
-except ImportError:
-    try:
-        from passlib.utils.pbkdf2 import pbkdf2 as _pbkdf2
-
-        def pbkdf2(val, salt, iterations, dklen, func):
-            return _pbkdf2(val, salt, iterations, dklen, ("hmac-" + func).encode("utf-8"))
-    except ImportError:
-        raise ImportError("No PBKDF2 implementation found. Either upgrade "
-                          "to `werkzeug` 0.9 or install `passlib`.")
+from werkzeug.security import pbkdf2_bin as pbkdf2
 
 
 def _TypeError(name, expected, val):

--- a/isso/wsgi.py
+++ b/isso/wsgi.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import sys
 import socket
 
 from urllib.parse import quote, urlparse
@@ -144,27 +143,6 @@ class CORSMiddleware(object):
             return []
 
         return self.app(environ, add_cors_headers)
-
-
-class LegacyWerkzeugMiddleware(object):
-    # Add compatibility with werkzeug 0.8
-    # -- https://github.com/posativ/isso/pull/170
-
-    def __init__(self, app):
-        self.app = app
-
-    def __call__(self, environ, start_response):
-
-        def to_native(x, charset=sys.getdefaultencoding(), errors='strict'):
-            if x is None or isinstance(x, str):
-                return x
-            return x.decode(charset, errors)
-
-        def fix_headers(status, headers, exc_info=None):
-            headers = [(to_native(key), value) for key, value in headers]
-            return start_response(status, headers, exc_info)
-
-        return self.app(environ, fix_headers)
 
 
 class Request(_Request):

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,10 @@ commands =
 
 [testenv:debian]
 deps=
-    bleach
+    itsdangerous
+    Jinja2
+    misaka>=2.0,<3.0
     html5lib
-    ipaddr==2.1.10
-    itsdangerous==0.22
-    misaka==1.0.2
-    passlib==1.5.3
-    werkzeug==0.8.3
+    werkzeug>=1.0
+    bleach
+    flask-caching>=1.9


### PR DESCRIPTION
Since 3e3ee8b, werkzeug is required in version 1.0 or above

Also align deps in `tox.ini` with the ones in `setup.py`