### PR TITLE
Serve isso.css separately instead of inline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog for Isso
 
 - Don't ignore missing configuration files.
   (Jelmer Vernooĳ)
+- Serve isso.css separately to avoid `style-src: unsafe-inline` CSP and allow
+  clients to override fetch location (#704, ix5):
+
+    data-isso-css-url="https://comments.example.org/css/isso.css"
 
 0.12.4 (2021-02-03)
 -------------------

--- a/docs/docs/configuration/client.rst
+++ b/docs/docs/configuration/client.rst
@@ -9,6 +9,7 @@ preferably in the script tag which embeds the JS:
     <script data-isso="/prefix/"
             data-isso-id="thread-id"
             data-isso-css="true"
+            data-isso-css-url="null"
             data-isso-lang="ru"
             data-isso-reply-to-self="false"
             data-isso-require-author="false"
@@ -96,6 +97,16 @@ override the API location:
 .. code-block:: html
 
     <script data-isso="/isso" src="/path/to/embed.min.js"></script>
+
+data-isso-css-url
+-----------------
+
+Set URL from which to fetch ``isso.css``, e.g. from a CDN.
+Defaults to fetching from the API endpoint.
+
+.. code-block:: html
+
+    <script src="..." data-isso-css-url="/path/to/isso.css"></script>
 
 data-isso-css
 -------------

--- a/isso/js/app/config.js
+++ b/isso/js/app/config.js
@@ -3,6 +3,7 @@ define(function() {
 
     var config = {
         "css": true,
+        "css-url": null,
         "lang": (navigator.language || navigator.userLanguage).split("-")[0],
         "reply-to-self": false,
         "require-email": false,

--- a/isso/js/app/text/css.js
+++ b/isso/js/app/text/css.js
@@ -1,5 +1,0 @@
-define(["text!../../../css/isso.css"], function(isso) {
-    return {
-        inline: isso
-    };
-});

--- a/isso/js/build.count.js
+++ b/isso/js/build.count.js
@@ -3,7 +3,6 @@
     mainConfigFile: 'config.js',
     paths: {
         "app/text/svg": "app/text/dummy",
-        "app/text/css": "app/text/dummy"
     },
 
     name: "../../node_modules/almond/almond",

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -3,7 +3,7 @@
  * Distributed under the MIT license
  */
 
-require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/count", "app/dom", "app/text/css", "app/text/svg", "app/jade"], function(domready, config, i18n, api, isso, count, $, css, svg, jade) {
+require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/count", "app/dom", "app/text/svg", "app/jade"], function(domready, config, i18n, api, isso, count, $, svg, jade) {
 
     "use strict";
 
@@ -20,10 +20,11 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
         heading = $.new("h4");
 
         if (config["css"] && $("style#isso-style") === null) {
-            var style = $.new("style");
+            var style = $.new("link");
             style.id = "isso-style";
+            style.rel ="stylesheet";
             style.type = "text/css";
-            style.textContent = css.inline;
+            style.href = config["css-url"] ? config["css-url"] : api.endpoint + "/css/isso.css";
             $("head").append(style);
         }
 


### PR DESCRIPTION
Instead of embedding isso.css inside the client javascript (which required an `style-src: unsafe-inline` CSP), fetch isso.css from `api.endpoint+"/css/isso.css"`.

Allow clients to override fetch location using `data-isso-css-url="https://comments.example.org/css/isso.css"`

Note: No modification needed for packaging since isso.css is already included via MANIFEST.in.

Fixes https://github.com/posativ/isso/issues/584