### PR TITLE
Feature: add webhook notification capability

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,6 +117,9 @@ In chronological order:
   * Update Polish translation
   * Redirect to comment after moderation
 
+* Julien Moura @Guts
+  * Notify through web hooks
+
 * fliiiix <l33t.name>
   * Import disqus posts without Email
   * Import disqus post without IP

--- a/contrib/webhook_template_slack.json
+++ b/contrib/webhook_template_slack.json
@@ -1,0 +1,70 @@
+{
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": ":speech_balloon: New comment posted",
+        "emoji": true
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Author:* $AUTHOR_NAME $AUTHOR_EMAIL $AUTHOR_WEBSITE"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*IP:* $COMMENT_IP_ADDRESS"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Comment:*\n$COMMENT_TEXT"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "emoji": true,
+            "text": ":eye-in-speech-bubble: View comment"
+          },
+          "url": "$COMMENT_URL_VIEW"
+        },
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "emoji": true,
+            "text": ":white_check_mark: Approve"
+          },
+          "style": "primary",
+          "url": "$COMMENT_URL_ACTIVATE"
+        },
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "emoji": true,
+            "text": ":wastebasket: Deny"
+          },
+          "style": "danger",
+          "url": "$COMMENT_URL_DELETE"
+        }
+      ]
+    }
+  ]
+}

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -69,7 +69,7 @@ from isso.wsgi import origin, urlsplit
 from isso.utils import http, JSONRequest, JSONResponse, hash
 from isso.views import comments
 
-from isso.ext.notifications import Stdout, SMTP
+from isso.ext.notifications import Stdout, SMTP, WebHook
 
 LOG_FORMAT = "%(asctime)s:%(levelname)s: %(message)s"
 logging.getLogger("werkzeug").setLevel(logging.WARN)
@@ -107,10 +107,12 @@ class Isso(object):
         subscribers = []
         smtp_backend = False
         for backend in conf.getlist("general", "notify"):
-            if backend == "stdout":
+            if backend.lower() == "stdout":
                 subscribers.append(Stdout(self))
-            elif backend in ("smtp", "SMTP"):
+            elif backend.lower() == "smtp":
                 smtp_backend = True
+            elif backend.lower() == "webhook":
+                subscribers.append(WebHook(self))
             else:
                 logger.warning("unknown notification backend '%s'", backend)
         if smtp_backend or conf.getboolean("general", "reply-notifications"):

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -275,7 +275,7 @@ class WebHook(object):
         if not isurl(self.wh_url):
             raise ValueError(
                 "Web hook requires a valid URL. "
-                f"The provided one is not correct: {self.wh_url}"
+                "The provided one is not correct: {}".format(self.wh_url)
             )
 
         # check optional template
@@ -283,7 +283,7 @@ class WebHook(object):
             self.wh_template = None
             logger.debug("No template provided.")
         elif not Path(self.wh_template).is_file():
-            raise FileExistsError(f"Invalid web hook template path: {self.wh_template}")
+            raise FileExistsError("Invalid web hook template path: {}".format(self.wh_template))
         else:
             self.wh_template = Path(self.wh_template)
 

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -28,7 +28,7 @@ from isso.views.comments import isurl
 def create_comment_action_url(uri, action, key):
     return uri + "/" + action + "/" + key
 
-from requests import Session
+from requests import HTTPError, Session
 
 # Globals
 logger = logging.getLogger("isso")
@@ -414,6 +414,16 @@ class WebHook(object):
                     ),
                 },
             )
+
+            try:
+                response.raise_for_status()
+                logger.info("Web hook sent to %s" % self.wh_url)
+            except HTTPError as err:
+                logger.error(
+                    "Something went wrong during POST request to the web hook. Trace: %s"
+                    % err
+                )
+                return False
 
         # if no error occurred
         return True

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -375,10 +375,6 @@ class WebHook(object):
         with self.wh_template.open("r") as in_file:
             tpl_json_data = json.load(in_file)
         tpl_str = Template(json.dumps(tpl_json_data))
-        print(type(tpl_str))
-
-        # build URLs
-        comment_urls = self.comment_urls(thread, comment)
 
         # substitute
         out_msg = tpl_str.substitute(

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -21,14 +21,14 @@ try:
 except ImportError:
     uwsgi = None
 
-from isso import local
-from isso.utils import http
+from isso import dist, local
 from isso.views.comments import isurl
 
 
 def create_comment_action_url(uri, action, key):
     return uri + "/" + action + "/" + key
 
+from requests import Session
 
 # Globals
 logger = logging.getLogger("isso")
@@ -260,7 +260,18 @@ class Stdout(object):
 
 
 class WebHook(object):
+    """Notification handler for web hook.
+
+    :param isso_instance: Isso application instance. Used to get moderation key.
+    :type isso_instance: object
+
+    :raises ValueError: if the provided URL is not valid
+    :raises FileExistsError: if the provided JSON template doesn't exist
+    :raises TypeError: if the provided template file is not a JSON
+    """
+
     def __init__(self, isso_instance: object):
+        """Instanciate class."""
         # store isso instance
         self.isso_instance = isso_instance
         # retrieve relevant configuration
@@ -283,30 +294,57 @@ class WebHook(object):
             self.wh_template = None
             logger.debug("No template provided.")
         elif not Path(self.wh_template).is_file():
-            raise FileExistsError("Invalid web hook template path: {}".format(self.wh_template))
+            raise FileExistsError(
+                "Invalid web hook template path: {}".format(self.wh_template)
+            )
+        elif not Path(self.wh_template).suffix == ".json":
+            raise TypeError()(
+                "Template must be a JSON file: {}".format(self.wh_template)
+            )
         else:
             self.wh_template = Path(self.wh_template)
 
     def __iter__(self):
 
-        yield "comments.new:after-save", self._new_comment
+        yield "comments.new:after-save", self.new_comment
 
-    def _new_comment(self, thread: dict, comment: dict):
+    def new_comment(self, thread: dict, comment: dict):
+        """Triggered when a new comment is saved.
 
-        if self.wh_template:
-            post_data = self.format(thread, comment)
-        else:
-            post_data = {
-                "author": comment.get("author", "Anonymous"),
-                "author_email": comment.get("email"),
-                "text": comment.get("text"),
-            }
-            print(post_data)
+        :param thread: comment thread
+        :type thread: dict
+        :param comment: comment object
+        :type comment: dict
+        """
 
-        self.send(post_data)
+        try:
+            # get moderation URLs
+            moderation_urls = self.moderation_urls(thread, comment)
 
-    def comment_urls(self, thread: dict, comment: dict) -> tuple:
+            if self.wh_template:
+                post_data = self.render_template(thread, comment, moderation_urls)
+            else:
+                post_data = {
+                    "author": comment.get("author", "Anonymous"),
+                    "author_email": comment.get("email"),
+                    "text": comment.get("text"),
+                }
 
+            self.send(post_data)
+        except Exception as err:
+            logger.error(err)
+
+    def moderation_urls(self, thread: dict, comment: dict) -> tuple:
+        """Helper to build comment related URLs (deletion, activation, etc.).
+
+        :param thread: comment thread
+        :type thread: dict
+        :param comment: comment object
+        :type comment: dict
+
+        :return: tuple of URS in alpha order (activate, admin, delete, view)
+        :rtype: tuple
+        """
         uri = "{}/id/{}".format(self.public_endpoint, comment.get("id"))
         key = self.isso_instance.sign(comment.get("id"))
 
@@ -318,11 +356,21 @@ class WebHook(object):
 
         return url_activate, url_delete, url_view
 
-    def format(
-        self,
-        thread: dict,
-        comment: dict,
+    def render_template(
+        self, thread: dict, comment: dict, moderation_urls: tuple
     ) -> str:
+        """Format comment information as webhook payload filling the specified template.
+
+        :param thread: isso thread
+        :type thread: dict
+        :param comment: isso comment
+        :type comment: dict
+        :param moderation_urls: comment moderation URLs
+        :type comment: tuple
+
+        :return: formatted message from template
+        :rtype: str
+        """
         # load template
         with self.wh_template.open("r") as in_file:
             tpl_json_data = json.load(in_file)
@@ -335,27 +383,37 @@ class WebHook(object):
         # substitute
         out_msg = tpl_str.substitute(
             AUTHOR_NAME=comment.get("author", "Anonymous"),
-            AUTHOR_EMAIL="<{}>".format(comment.get("email")),
-            AUTHOR_WEBSITE=comment.get("website"),
+            AUTHOR_EMAIL="<{}>".format(comment.get("email", "")),
+            AUTHOR_WEBSITE=comment.get("website", ""),
             COMMENT_IP_ADDRESS=comment.get("remote_addr"),
             COMMENT_TEXT=comment.get("text"),
-            COMMENT_URL_ACTIVATE=comment_urls[0],
-            COMMENT_URL_DELETE=comment_urls[1],
-            COMMENT_URL_VIEW=comment_urls[2],
+            COMMENT_URL_ACTIVATE=moderation_urls[0],
+            COMMENT_URL_DELETE=moderation_urls[1],
+            COMMENT_URL_VIEW=moderation_urls[2],
         )
 
         return out_msg
 
-    def send(self, structured_msg: dict) -> bool:
+    def send(self, structured_msg: str) -> bool:
         """Send the structured message as a notification to the class webhook URL.
 
-        :param dict structured_msg: structured message to send
+        :param str structured_msg: structured message to send
 
         :rtype: bool
         """
-        with http.curl("POST", self.wh_url, "/") as resp:
-            if resp:  # may be None if request failed
-                return resp.status
+        with Session() as requests_session:
+
+            # send requests
+            response = requests_session.post(
+                url=self.wh_url,
+                data=structured_msg,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "Isso/{0} (+https://posativ.org/isso)".format(
+                        dist.version
+                    ),
+                },
+            )
 
         # if no error occurred
         return True

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -335,7 +335,7 @@ class WebHook(object):
         # substitute
         out_msg = tpl_str.substitute(
             AUTHOR_NAME=comment.get("author", "Anonymous"),
-            AUTHOR_EMAIL="<>".format(comment.get("email")),
+            AUTHOR_EMAIL="<{}>".format(comment.get("email")),
             AUTHOR_WEBSITE=comment.get("website"),
             COMMENT_IP_ADDRESS=comment.get("remote_addr"),
             COMMENT_TEXT=comment.get("text"),

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -274,8 +274,8 @@ class WebHook(object):
         # check required settings
         if not isurl(self.wh_url):
             raise ValueError(
-                f"Web hook requires a valid URL. "
-                "The provided one is not correct: {self.wh_url}"
+                "Web hook requires a valid URL. "
+                f"The provided one is not correct: {self.wh_url}"
             )
 
         # check optional template

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -9,11 +9,12 @@ import time
 from _thread import start_new_thread
 from email.message import EmailMessage
 from email.utils import formatdate
+from pathlib import Path
+from string import Template
 from urllib.parse import quote
 
 import logging
 
-logger = logging.getLogger("isso")
 
 try:
     import uwsgi
@@ -21,10 +22,16 @@ except ImportError:
     uwsgi = None
 
 from isso import local
+from isso.utils import http
+from isso.views.comments import isurl
 
 
 def create_comment_action_url(uri, action, key):
     return uri + "/" + action + "/" + key
+
+
+# Globals
+logger = logging.getLogger("isso")
 
 
 class SMTPConnection(object):
@@ -250,3 +257,105 @@ class Stdout(object):
 
     def _activate_comment(self, thread, comment):
         logger.info("comment %(id)s activated" % thread)
+
+
+class WebHook(object):
+    def __init__(self, isso_instance: object):
+        # store isso instance
+        self.isso_instance = isso_instance
+        # retrieve relevant configuration
+        self.public_endpoint = isso_instance.conf.get(
+            section="server", option="public-endpoint"
+        ) or local("host")
+        webhook_conf_section = isso_instance.conf.section("webhook")
+        self.wh_url = webhook_conf_section.get("url")
+        self.wh_template = webhook_conf_section.get("template")
+
+        # check required settings
+        if not isurl(self.wh_url):
+            raise ValueError(
+                f"Web hook requires a valid URL. "
+                "The provided one is not correct: {self.wh_url}"
+            )
+
+        # check optional template
+        if not len(self.wh_template):
+            self.wh_template = None
+            logger.debug("No template provided.")
+        elif not Path(self.wh_template).is_file():
+            raise FileExistsError(f"Invalid web hook template path: {self.wh_template}")
+        else:
+            self.wh_template = Path(self.wh_template)
+
+    def __iter__(self):
+
+        yield "comments.new:after-save", self._new_comment
+
+    def _new_comment(self, thread: dict, comment: dict):
+
+        if self.wh_template:
+            post_data = self.format(thread, comment)
+        else:
+            post_data = {
+                "author": comment.get("author", "Anonymous"),
+                "author_email": comment.get("email"),
+                "text": comment.get("text"),
+            }
+            print(post_data)
+
+        self.send(post_data)
+
+    def comment_urls(self, thread: dict, comment: dict) -> tuple:
+
+        uri = "{}/id/{}".format(self.public_endpoint, comment.get("id"))
+        key = self.isso_instance.sign(comment.get("id"))
+
+        url_activate = "{}/activate/{}".format(uri, key)
+        url_delete = "{}/delete/{}".format(uri, key)
+        url_view = "{}#isso-{}".format(
+            local("origin") + thread.get("uri"), comment.get("id")
+        )
+
+        return url_activate, url_delete, url_view
+
+    def format(
+        self,
+        thread: dict,
+        comment: dict,
+    ) -> str:
+        # load template
+        with self.wh_template.open("r") as in_file:
+            tpl_json_data = json.load(in_file)
+        tpl_str = Template(json.dumps(tpl_json_data))
+        print(type(tpl_str))
+
+        # build URLs
+        comment_urls = self.comment_urls(thread, comment)
+
+        # substitute
+        out_msg = tpl_str.substitute(
+            AUTHOR_NAME=comment.get("author", "Anonymous"),
+            AUTHOR_EMAIL="<>".format(comment.get("email")),
+            AUTHOR_WEBSITE=comment.get("website"),
+            COMMENT_IP_ADDRESS=comment.get("remote_addr"),
+            COMMENT_TEXT=comment.get("text"),
+            COMMENT_URL_ACTIVATE=comment_urls[0],
+            COMMENT_URL_DELETE=comment_urls[1],
+            COMMENT_URL_VIEW=comment_urls[2],
+        )
+
+        return out_msg
+
+    def send(self, structured_msg: dict) -> bool:
+        """Send the structured message as a notification to the class webhook URL.
+
+        :param dict structured_msg: structured message to send
+
+        :rtype: bool
+        """
+        with http.curl("POST", self.wh_url, "/") as resp:
+            if resp:  # may be None if request failed
+                return resp.status
+
+        # if no error occurred
+        return True

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -408,12 +408,15 @@ class WebHook(object):
 
         :rtype: bool
         """
+        # load the message to ensure encoding
+        msg_json = json.loads(structured_msg)
+
         with Session() as requests_session:
 
             # send requests
             response = requests_session.post(
                 url=self.wh_url,
-                data=structured_msg,
+                json=json.dumps(msg_json),
                 headers={
                     "Content-Type": "application/json",
                     "User-Agent": "Isso/{0} (+https://posativ.org/isso)".format(

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -308,13 +308,16 @@ class WebHook(object):
 
         yield "comments.new:after-save", self.new_comment
 
-    def new_comment(self, thread: dict, comment: dict):
+    def new_comment(self, thread: dict, comment: dict) -> bool:
         """Triggered when a new comment is saved.
 
         :param thread: comment thread
         :type thread: dict
         :param comment: comment object
         :type comment: dict
+
+        :return: True if eveythring went fine. False if not.
+        :rtype: bool
         """
 
         try:
@@ -325,14 +328,22 @@ class WebHook(object):
                 post_data = self.render_template(thread, comment, moderation_urls)
             else:
                 post_data = {
-                    "author": comment.get("author", "Anonymous"),
+                    "author_name": comment.get("author", "Anonymous"),
                     "author_email": comment.get("email"),
-                    "text": comment.get("text"),
+                    "author_website": comment.get("website"),
+                    "comment_ip_address": comment.get("remote_addr"),
+                    "comment_text": comment.get("text"),
+                    "comment_url_activate": moderation_urls[0],
+                    "comment_url_delete": moderation_urls[1],
+                    "comment_url_view": moderation_urls[2],
                 }
 
             self.send(post_data)
         except Exception as err:
             logger.error(err)
+            return False
+
+        return True
 
     def moderation_urls(self, thread: dict, comment: dict) -> tuple:
         """Helper to build comment related URLs (deletion, activation, etc.).

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -271,3 +271,15 @@ base =
 
 # Limit the number of elements to return for each thread.
 limit = 100
+
+[webhook]
+# Isso can notify you on new comments via web hook.
+# By default, it sends a POST data with new comment metadata: author, author email, author website, text, moderation URLs (activation, deletion, view).
+# It's also possible to add a JSON template (using Python string.Template) to customize the POST data. Useful to fit some tools abilities ike Slack, Matrix, Teams, etc.
+# An example for Slack with block builder is prodived in the contrib folder.
+
+# webhook URL
+url = 
+
+# path to the JSON template. Optional.
+template = 

--- a/isso/tests/test_vote.py
+++ b/isso/tests/test_vote.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
 
 import json
 import tempfile
@@ -11,6 +11,7 @@ from isso.utils import http
 
 from fixtures import curl, loads, FakeIP, JSONClient
 
+
 http.curl = curl
 
 
@@ -19,7 +20,8 @@ class TestVote(unittest.TestCase):
         self.path = tempfile.NamedTemporaryFile().name
 
     def makeClient(self, ip):
-        conf = config.load(config.default_file())
+
+        conf = config.load(pkg_resources.resource_filename("isso", "defaults.ini"))
         conf.set("general", "dbpath", self.path)
         conf.set("guard", "enabled", "off")
         conf.set("hash", "algorithm", "none")
@@ -33,12 +35,18 @@ class TestVote(unittest.TestCase):
         return JSONClient(app, Response)
 
     def testZeroLikes(self):
-        rv = self.makeClient("127.0.0.1").post("/new?uri=test", data=json.dumps({"text": "..."}))
+
+        rv = self.makeClient("127.0.0.1").post(
+            "/new?uri=test", data=json.dumps({"text": "..."})
+        )
         self.assertEqual(loads(rv.data)["likes"], 0)
         self.assertEqual(loads(rv.data)["dislikes"], 0)
 
     def testSingleLike(self):
-        self.makeClient("127.0.0.1").post("/new?uri=test", data=json.dumps({"text": "..."}))
+
+        self.makeClient("127.0.0.1").post(
+            "/new?uri=test", data=json.dumps({"text": "..."})
+        )
         rv = self.makeClient("0.0.0.0").post("/id/1/like")
 
         self.assertEqual(rv.status_code, 200)
@@ -48,12 +56,16 @@ class TestVote(unittest.TestCase):
         bob = self.makeClient("127.0.0.1")
         bob.post("/new?uri=test", data=json.dumps({"text": "..."}))
         rv = bob.post("/id/1/like")
+        rv = bob.post("/id/1/like")
 
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(loads(rv.data)["likes"], 0)
 
     def testMultipleLikes(self):
-        self.makeClient("127.0.0.1").post("/new?uri=test", data=json.dumps({"text": "..."}))
+
+        self.makeClient("127.0.0.1").post(
+            "/new?uri=test", data=json.dumps({"text": "..."})
+        )
         for num in range(15):
             rv = self.makeClient("1.2.%i.0" % num).post("/id/1/like")
             self.assertEqual(rv.status_code, 200)
@@ -65,7 +77,10 @@ class TestVote(unittest.TestCase):
         self.assertEqual(loads(rv.data), None)
 
     def testTooManyLikes(self):
-        self.makeClient("127.0.0.1").post("/new?uri=test", data=json.dumps({"text": "..."}))
+
+        self.makeClient("127.0.0.1").post(
+            "/new?uri=test", data=json.dumps({"text": "..."})
+        )
         for num in range(256):
             rv = self.makeClient("1.2.%i.0" % num).post("/id/1/like")
             self.assertEqual(rv.status_code, 200)
@@ -76,7 +91,9 @@ class TestVote(unittest.TestCase):
                 self.assertEqual(loads(rv.data)["likes"], num + 1)
 
     def testDislike(self):
-        self.makeClient("127.0.0.1").post("/new?uri=test", data=json.dumps({"text": "..."}))
+        self.makeClient("127.0.0.1").post(
+            "/new?uri=test", data=json.dumps({"text": "..."})
+        )
         rv = self.makeClient("1.2.3.4").post("/id/1/dislike")
 
         self.assertEqual(rv.status_code, 200)

--- a/tox.ini
+++ b/tox.ini
@@ -19,4 +19,5 @@ deps=
     Jinja2
     misaka>=2.0,<3.0
     passlib==1.5.3
+    requests>=2.25,<2.26
     werkzeug>=1.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,12 @@ commands =
 
 [testenv:debian]
 deps=
+    bleach
+    flask-caching>=1.9,<1.11
+    html5lib
+    ipaddr==2.1.10
     itsdangerous
     Jinja2
     misaka>=2.0,<3.0
-    mistune>=3.1,<4.0
-    html5lib
+    passlib==1.5.3
     werkzeug>=1.0
-    bleach
-    flask-caching>=1.9


### PR DESCRIPTION
I propose here to add the possibility to send a notification to a web hook for each new comment.

# Notable changes

- creation of a new WebHook class in the notifications module
- by default, it sends a POST request with the same metadata as the mail notification (name, mail and site of the author as well as the moderation links)
- add requests as dependency
- possibility for the end user to pass a JSON template to the webhook (useful for tools allowing formatting, like Slack/Teams/Matrix...). An example of template for Slack is provided (into contrib subfolder) with this render:

![image](https://user-images.githubusercontent.com/1596222/116780299-1c284580-aa7c-11eb-8058-404355db5c8b.png)

# Questions

- Maybe it is possible with Werkzeug, Flask or the stdlib directly for the POST request? I'm not expert on this side so, don't hesitate on review my code.
- I wanted to use f-strings but apparently the project is still tested on Python 3.5 (which has reached EOL), but not 3.9. Is it a voluntary choice?
- I had to fix dependencies consistency between setup.py and tox.ini, in order to get CI fixed. Requirements are not well documented and the development workflow is quite unclear. Would you accept a PR to switch to requirements.txt files and/or pyproject.tom (recomended by tox anyway)?

# Misc

- add cache to Travis to make it faster
- Close my question #722