### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,20 +13,21 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Check out repository code
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python setup.py develop
-    - name: Style checks
-      run: |
-        python -m flakes
-    - name: Test suite run
-      run: |
-        make test
+    - name: Install isso dependencies
+      run: python setup.py develop
+    - name: Install test suite dependencies
+      run: pip3 install nose
+    - name: Run test suite
+      run: make test
       env:
         PYTHONHASHSEED: random
+    - name: Install style check dependencies
+      run: pip3 install flake8
+    - name: Run style check
+      run: make flakes

--- a/isso/dispatch.py
+++ b/isso/dispatch.py
@@ -12,7 +12,7 @@ import pkg_resources
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.wrappers import Response
 
-from isso import dist, make_app, wsgi, config
+from isso import make_app, wsgi, config
 
 logger = logging.getLogger("isso")
 

--- a/isso/run.py
+++ b/isso/run.py
@@ -6,7 +6,7 @@ import os
 import pkg_resources
 
 from isso import make_app
-from isso import dist, config
+from isso import config
 
 application = make_app(
     config.load(

--- a/isso/tests/test_guard.py
+++ b/isso/tests/test_guard.py
@@ -11,7 +11,7 @@ from werkzeug import __version__
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
-from isso import Isso, config, core, dist
+from isso import Isso, config, core
 from isso.utils import http
 
 from fixtures import curl, FakeIP

--- a/isso/tests/test_vote.py
+++ b/isso/tests/test_vote.py
@@ -1,7 +1,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import json
 import tempfile
 import pkg_resources
@@ -9,7 +8,7 @@ import unittest
 
 from werkzeug.wrappers import Response
 
-from isso import Isso, core, config, dist
+from isso import Isso, core, config
 from isso.utils import http
 
 from fixtures import curl, loads, FakeIP, JSONClient

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 
-import sys
-
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
-            'werkzeug>=1.0', 'bleach', 'Flask-Caching>=1.9']
+            'werkzeug>=1.0', 'bleach', 'Flask-Caching>=1.9', 'Flask']
 
 setup(
     name='isso',


### PR DESCRIPTION
This PR fixed the dependency issues that causes CI test to fail.

Unless isso explicitly supports Windows and PyPy3, I don't think we should include them in the CI test.
Also we should consider drop the support for Python 3.5 [which reached end-of-life](https://www.python.org/downloads/release/python-3510/).