### PR TITLE
[ISSUE TEMPLATES] Add Issue Form for bug reporting, feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: <Type in title here>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report. Before opening a bug report, please research whether your issue or anything similar has already been reported.
+  - type: input
+    id: version
+    attributes:
+      label: Isso Version
+      description: What version of isso are you using? If you are using the latest version from git, please type in the commit SHA1
+      placeholder: 0.12.4
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: Which python version are you using?
+      placeholder: Python 3.7
+    validations:
+      required: true
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      description: What Operating System are you using?
+      placeholder: Ubuntu 20.04
+  - type: input
+    id: webserver
+    attributes:
+      label: Web server
+      description: If you are using a web server to run Isso, which are you using?
+      placeholder: Apache 2.4
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce your issue?
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Isso configuration
+      description: Please copy and paste your isso configuration ("isso.cfg"). You should censor any private information such as email addresses and passwords. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Request a feature
+title: "[FEATURE]: <Type in title here>"
+labels: ["feature", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to diligently document your feature request.
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: What is Isso's current behavior?
+      description: Also, please explain why that behavior should be changed.
+    validations:
+      required: true
+  - type: textarea
+    id: desired-behavior
+    attributes:
+      label: What would you like Isso to do differently?
+      description: Please get into detail of how you expect the feature or change to work.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you are willing to (help) develop it yourself, you can also open a [Pull Request](https://github.com/posativ/isso/pulls) with your desired changes!


### PR DESCRIPTION
GitHub has recently introduced their new "Issue Forms" as a public beta. This feature allows collecting user input in a structured form and guides them towards generating actionable bugs.

For more information, please see the [public announcement](https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/) and the [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

For anyone wanting to test out how the form would present itself, please see https://github.com/ix5/isso/issues/new/choose