### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+exclude: "node_modules|.venv|isso/tests"
+
+repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: check-executables-have-shebangs
+      - id: check-case-conflict
+      - id: check-yaml
+        args: [--unsafe]
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-encoding-pragma
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        language: python
+        files: ^isso/.*\.py$
+        types: [python]
+        args: ["--config=setup.cfg", "--select=E9,F63,F7,F82"]
+
+# Specific part for https://pre-commit.ci
+ci:
+  autofix_prs: true
+  autoupdate_schedule: quarterly
+  skip: [
+    "check-hooks-apply"
+  ]
+  submodules: false

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
     install_requires=requires,
     extras_require={
         "dev": [
-                    "pre-commit>=2.15,<2.18",
-                    "flake8>4,<4.1",
+            "pre-commit>=2.15,<2.18",
+            "flake8>4,<4.1",
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                     "pre-commit>=2.15,<2.18",
                     "flake8>4,<4.1",
         ],
-    }
+    },
     entry_points={
         'console_scripts':
             ['isso = isso:main'],

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,12 @@ setup(
         "Programming Language :: Python :: 3.9"
     ],
     install_requires=requires,
+    extras_require={
+        "dev": [
+                    "pre-commit>=2.15,<2.18",
+                    "flake8>4,<4.1",
+        ],
+    }
     entry_points={
         'console_scripts':
             ['isso = isso:main'],


### PR DESCRIPTION
**In this PR**

- add classical git hooks through [pre-commit](https://pre-commit.com/) to prevent "simple" issues when pushing code
- add basic flake8 git hook, reusing configuration from setup.cfg and selecting most important flags
- add specific section for https://pre-commit.ci/ - recommended because it automates hook updates and quick fixes when it's possible. This requires that a member with write permissions registers the repository on the application.
- add required as extra dependencies into setup.py for development

**Goal**

A little step to improve code reliability.

**Related issues**

Related to #755 