### PR TITLE
Avoid TypeError when #isso-root is not in the DOM

### DIFF
--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -48,7 +48,7 @@ require(["app/lib/ready", "app/config", "app/i18n", "app/api", "app/isso", "app/
 
     function fetchComments() {
 
-        if ($('#isso-root').length == 0) {
+        if (!$('#isso-root')) {
             return;
         }
 


### PR DESCRIPTION
`$(...)` returns `null` when the selector matches no element, and thus `$(...).length == 0` should not be used.

Fixes #306 