### PR TITLE
Dockerfile: Set TOX_ENV to use artifacts from nodejs build instead of building inside Python container (fixes #759)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN make init js
 # Second, create virtualenv
 FROM python:3.8-buster AS venvBuilder
 WORKDIR /src/
+ENV TOX_ENV=1
 COPY --from=jsBuilder /src .
 RUN python3 -m venv /isso \
  && . /isso/bin/activate \


### PR DESCRIPTION
I don't know what the purpose of that `TOX_ENV` value was, but it seems to do the trick.