### PR TITLE
docs: quickstart: fix comment in sample config

### DIFF
--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -19,7 +19,7 @@ sane defaults.
 
     [general]
     ; database location, check permissions, automatically created if it
-    does not exist
+    ; does not exist
     dbpath = /var/lib/isso/comments.db
     ; your website or blog (not the location of Isso!)
     host = http://example.tld/


### PR DESCRIPTION
redo #768 

since code blocks don't unwrap lines, part of comment in config example is rendered as non-comment.

added `;` to start of line to fix that.