### PR TITLE
[UGLY] admin: Use textarea for comment editing

### DIFF
--- a/isso/css/admin.css
+++ b/isso/css/admin.css
@@ -135,3 +135,10 @@ a {
 .hidden {
   display: none;
 }
+.text-wrapper .text {
+    margin: 0.5em 0;
+}
+.text-wrapper .text textarea {
+    width: 100%;
+    margin-top: 1em;
+}

--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -123,7 +123,7 @@
         {% if comment.mode == 4 %}
           <strong>HIDDEN</strong>. Original text: <br />
         {% endif %}
-        <div id="isso-text-{{comment.id}}"><pre>{{comment.text}}</pre></div>
+        <pre id="isso-text-{{comment.id}}">{{comment.text}}</pre>
       </div>
       <div class='isso-comment-footer'>
         {% if conf.votes and comment.likes - comment.dislikes != 0 %}


### PR DESCRIPTION
Use a `<textarea>` element to let the user properly edit comments, where `contenteditable` was poorly suited for multi-line input.

---

If anyone has a cleaner solution, go for it.
This is my stopgap solution to make comment editing in the admin work again (which got bungled by the combination of https://github.com/posativ/isso/pull/470 and https://github.com/posativ/isso/pull/604, where currently the edited content is wrapped in unwanted literal `<pre>` tags)