### PR TITLE
comment moderation fix item value check

### DIFF
--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -659,11 +659,11 @@ class API(object):
             raise Forbidden
 
         item = self.comments.get(id)
-        thread = self.threads.get(item['tid'])
-        link = local("origin") + thread["uri"] + "#isso-%i" % item["id"]
-
         if item is None:
             raise NotFound
+
+        thread = self.threads.get(item['tid'])
+        link = local("origin") + thread["uri"] + "#isso-%i" % item["id"]
 
         if request.method == "GET":
             modal = (


### PR DESCRIPTION
The item check should happen before we try to access
the value not after otherwise it results in a backtracke like this:

gunicorn[441]: 2022-02-17 20:46:52,526 ERROR: GET /id/2038/delete/XXXXXXXXXXXX
gunicorn[441]: Traceback (most recent call last):
gunicorn[441]:   File "/opt/isso/lib/python3.6/site-packages/isso/__init__.py", line 150, in dispatch
gunicorn[441]:     response = handler(request.environ, request, **values)
gunicorn[441]:   File "/opt/isso/lib/python3.6/site-packages/isso/views/comments.py", line 635, in moderate
gunicorn[441]:     thread = self.threads.get(item['tid'])
gunicorn[441]: TypeError: 'NoneType' object is not subscriptable

Now we return a item NotFound instead.

Signed-off-by: fliiiix <hi@l33t.name>