### PR TITLE
setup.py, README: Generate proper Project Description for PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Isso – *Ich schrei sonst* – is a lightweight commenting server written in
 Python and JavaScript. It aims to be a drop-in replacement for
 [Disqus](http://disqus.com).
 
-![Isso in Action](http://posativ.org/~tmp/isso-sample.png)
+See **[posativ.org/isso](http://posativ.org/isso/)** for more details and
+documentation.
 
-See [posativ.org/isso](http://posativ.org/isso/) for more details.
+![Isso in Action](http://posativ.org/~tmp/isso-sample.png)
 
 ## License
 MIT, see [LICENSE](LICENSE).

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 
+from pathlib import Path
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
             'werkzeug>=1.0', 'bleach', 'Flask-Caching>=1.9', 'Flask']
 tests_require = ['pytest', 'pytest-cov']
+
+# https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='isso',
@@ -18,6 +23,8 @@ setup(
     url='https://github.com/posativ/isso/',
     license='MIT',
     description='lightweight Disqus alternative',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     python_requires='>=3.5',
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 
 from pathlib import Path
+from re import sub as re_sub
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
@@ -11,6 +12,9 @@ tests_require = ['pytest', 'pytest-cov']
 # https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+# Filter out "License" section since license already displayed in PyPi sidebar
+# Remember to keep this in sync with changes to README!
+long_description = re_sub(r"\n## License\n.*LICENSE.*\n", "", long_description)
 
 setup(
     name='isso',


### PR DESCRIPTION
### setup.py: Include README in pypi upload

This allows for more information by embedding the README at https://pypi.org/project/isso/ as a "Project Description".

### README: ~~Point LICENSE to current GH master,~~ shuffle sections a bit

~~Reasoning: Use absolute link to allow embedding the rendered README on pypi (where the relative-path LICENSE is not available).~~