### PR TITLE
views: moderation: Add unit tests, proper response instead of "Yo", apiDoc clarifications

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -117,5 +117,11 @@ In chronological order:
   * Update Polish translation
   * Redirect to comment after moderation
 
+* fliiiix <l33t.name>
+  * Import disqus posts without Email
+  * Import disqus post without IP
+  * Fixing minor code inconsistencies
+  * Testing for moderation and unsubscribe
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -621,7 +621,7 @@ class TestModeratedComments(unittest.TestCase):
         action = "activate"
         rv_activated = self.client.post('/id/%d/%s/%s' % (id_, action, signed))
         self.assertEqual(rv_activated.status_code, 200)
-        self.assertEqual(rv_activated.data, b"Yo")
+        self.assertEqual(rv_activated.data, b"Comment has been activated")
 
         # Activating should be idempotent
         rv_activated = self.client.post('/id/%d/%s/%s' % (id_, action, signed))
@@ -635,7 +635,7 @@ class TestModeratedComments(unittest.TestCase):
         action = "delete"
         rv_deleted = self.client.post('/id/%d/%s/%s' % (id_, action, signed))
         self.assertEqual(rv_deleted.status_code, 200)
-        self.assertEqual(rv_deleted.data, b"Yo")
+        self.assertEqual(rv_deleted.data, b"Comment has been deleted")
 
         # Comment should no longer exist
         self.assertEqual(self.app.db.comments.get(id_), None)

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -696,6 +696,16 @@ class TestUnsubscribe(unittest.TestCase):
         self.assertEqual(rv_unsubscribe_get.status_code, 200)
         self.assertIn(b"Successfully unsubscribed", rv_unsubscribe_get.data)
 
+        # Incomplete key should fail
+        key = self.app.sign(['unsubscribe'])
+        rv_incomplete_key = self.client.get('/id/%d/unsubscribe/%s/%s' % (id_, email, key))
+        self.assertEqual(rv_incomplete_key.status_code, 403)
+
+        # Wrong key type should fail
+        key = self.app.sign(1)
+        rv_wrong_key_type = self.client.get('/id/%d/unsubscribe/%s/%s' % (id_, email, key))
+        self.assertEqual(rv_wrong_key_type.status_code, 403)
+
 
 class TestPurgeComments(unittest.TestCase):
 

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -631,6 +631,13 @@ class TestModeratedComments(unittest.TestCase):
         # Comment should have mode=1 (activated)
         self.assertEqual(self.app.db.comments.get(id_)["mode"], 1)
 
+        # Edit comment
+        action = "edit"
+        rv_edit = self.client.post('/id/%d/%s/%s' % (id_, action, signed), data=json.dumps({"text": "new text"}))
+        self.assertEqual(rv_edit.status_code, 200)
+        self.assertEqual(json.loads(rv_edit.data)["id"], id_)
+        self.assertEqual(self.app.db.comments.get(id_)["text"], "new text")
+
         # Delete comment
         action = "delete"
         rv_deleted = self.client.post('/id/%d/%s/%s' % (id_, action, signed))

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -617,6 +617,13 @@ class TestModeratedComments(unittest.TestCase):
         self.assertEqual(self.app.db.comments.get(id_)["mode"], 2)
         self.assertEqual(self.app.db.comments.get(id_)["text"], "...")
 
+        # GET should return some html form
+        action = "activate"
+        rv_activate_get = self.client.get('/id/%d/%s/%s' % (id_, action, signed))
+        self.assertEqual(rv_activate_get.status_code, 200)
+        self.assertIn(b"Activate: Are you sure?", rv_activate_get.data)
+        self.assertIn(b"http://invalid.local/moderated#isso-1", rv_activate_get.data)
+
         # Activate comment
         action = "activate"
         rv_activated = self.client.post('/id/%d/%s/%s' % (id_, action, signed))

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -638,6 +638,11 @@ class TestModeratedComments(unittest.TestCase):
         self.assertEqual(json.loads(rv_edit.data)["id"], id_)
         self.assertEqual(self.app.db.comments.get(id_)["text"], "new text")
 
+        # Wrong action on comment is handled by the routing
+        action = "foo"
+        rv_wrong_action = self.client.post('/id/%d/%s/%s' % (id_, action, signed))
+        self.assertEqual(rv_wrong_action.status_code, 404)
+
         # Delete comment
         action = "delete"
         rv_deleted = self.client.post('/id/%d/%s/%s' % (id_, action, signed))

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -584,6 +584,9 @@ class API(object):
         except (BadSignature, SignatureExpired):
             raise Forbidden
 
+        if not isinstance(rv, list) or len(rv) != 2:
+            raise Forbidden
+
         if rv[0] != 'unsubscribe' or rv[1] != email:
             raise Forbidden
 

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -551,7 +551,7 @@ class API(object):
         return resp
 
     """
-    @api {get} /id/:id/:email/key unsubscribe
+    @api {get} /id/:id/unsubscribe/:email/key unsubscribe
     @apiGroup Comment
     @apiDescription
         Opt out from getting any further email notifications about replies to a particular comment. In order to use this endpoint, the requestor needs a `key` that is usually obtained from an email sent out by isso.
@@ -561,7 +561,7 @@ class API(object):
     @apiParam {string} email
         The email address of the subscriber.
     @apiParam {string} key
-        The key to authenticate the subscriber. Containing a list with the keyword unsubscribe and the email ['unsubscribe', email].
+        The key to authenticate the subscriber.
 
     @apiExample {curl} Unsubscribe Alice from replies to comment with id 13:
         curl -X GET 'https://comments.example.com/id/13/unsubscribe/alice@example.com/WyJ1bnN1YnNjcmliZSIsImFsaWNlQGV4YW1wbGUuY29tIl0.DdcH9w.Wxou-l22ySLFkKUs7RUHnoM8Kos'

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -624,7 +624,7 @@ class API(object):
 
     @apiParam {number} id
         The id of the comment to moderate.
-    @apiParam {string=activate,delete} action
+    @apiParam {string=activate,edit,delete} action
         `activate` to publish the comment (change its mode to `1`).
         `delete` to delete the comment
     @apiParam {string} key

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -561,7 +561,7 @@ class API(object):
     @apiParam {string} email
         The email address of the subscriber.
     @apiParam {string} key
-        The key to authenticate the subscriber.
+        The key to authenticate the subscriber. Containing a list with the keyword unsubscribe and the email ['unsubscribe', email].
 
     @apiExample {curl} Unsubscribe Alice from replies to comment with id 13:
         curl -X GET 'https://comments.example.com/id/13/unsubscribe/alice@example.com/WyJ1bnN1YnNjcmliZSIsImFsaWNlQGV4YW1wbGUuY29tIl0.DdcH9w.Wxou-l22ySLFkKUs7RUHnoM8Kos'
@@ -569,17 +569,11 @@ class API(object):
     @apiSuccessExample {html} Using GET:
         &lt;!DOCTYPE html&gt;
         &lt;html&gt;
-            &lt;head&gt;
-                &lt;script&gt;
-                    if (confirm('Delete: Are you sure?')) {
-                        xhr = new XMLHttpRequest;
-                        xhr.open('POST', window.location.href);
-                        xhr.send(null);
-                    }
-                &lt;/script&gt;
-
-    @apiSuccessExample Using POST:
-        Yo
+            &lt;head&gtSuccessfully unsubscribed&lt;/head&gt;
+            &lt;body&gt;
+              &lt;p&gt;You have been unsubscribed from replies in the given conversation.&lt;/p&gt;
+            &lt;/body&gt;
+        &lt;/html&gt;
     """
 
     def unsubscribe(self, environ, request, id, email, key):

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -649,7 +649,7 @@ class API(object):
                 &lt;/script&gt;
 
     @apiSuccessExample Using POST:
-        Yo
+        Comment has been deleted
     """
 
     def moderate(self, environ, request, id, action, key):
@@ -689,7 +689,7 @@ class API(object):
             with self.isso.lock:
                 self.comments.activate(id)
             self.signal("comments.activate", thread, item)
-            return Response("Yo", 200)
+            return Response("Comment has been activated", 200)
         elif action == "edit":
             data = request.get_json()
             with self.isso.lock:
@@ -704,7 +704,7 @@ class API(object):
             self.cache.delete(
                 'hash', (item['email'] or item['remote_addr']).encode('utf-8'))
             self.signal("comments.delete", id)
-            return Response("Yo", 200)
+            return Response("Comment has been deleted", 200)
 
         """
         @api {get} / get comments


### PR DESCRIPTION
Things this PR addresses:
* Replace Yo response from moderation with a more appropriate response
* Add tests for moderation
* Add tests for unsubscribe and fix doc string

Contributes to #755 