### PR TITLE
__init__.py: Fix config startup check

### DIFF
--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -177,6 +177,10 @@ def make_app(conf=None, threading=True, multiprocessing=False, uwsgi=False):
 
     isso = App(conf)
 
+    if not any(conf.getiter("general", "host")):
+        logger.error("No website(s) configured, Isso won't work.")
+        sys.exit(1)
+
     # check HTTP server connection
     for host in conf.getiter("general", "host"):
         with http.curl('HEAD', host, '/', 5) as resp:
@@ -259,10 +263,6 @@ def main():
 
         logger.propagate = False
         logging.getLogger("werkzeug").propagate = False
-
-    if not any(conf.getiter("general", "host")):
-        logger.error("No website(s) configured, Isso won't work.")
-        sys.exit(1)
 
     if conf.get("server", "listen").startswith("http://"):
         host, port, _ = urlsplit(conf.get("server", "listen"))

--- a/isso/run.py
+++ b/isso/run.py
@@ -1,9 +1,18 @@
 # -*- encoding: utf-8 -*-
 
 import os
+import sys
 import pkg_resources
 
 from isso import config, make_app
+
+# Mock make_app because it is run by pytest
+# with the --doctest-modules flag
+# which will fail because make_app will exit
+# without valid configuration
+# https://stackoverflow.com/a/44595269/1279355
+if "pytest" in sys.modules:
+    make_app = lambda config, multiprocessing: True # noqa
 
 application = make_app(
     config.load(


### PR DESCRIPTION
gunicorn is not using main() it uses make_app via run.py.
Because of that we should check for the config file inside
make_app.
This is probably also true for other deployment options.