### PR TITLE
docs, demo: <noscript> to warn that JS is needed

### DIFF
--- a/docs/docs/quickstart.rst
+++ b/docs/docs/quickstart.rst
@@ -130,7 +130,9 @@ Now, you embed Isso to your website:
     <script data-isso="//comments.example.tld/"
             src="//comments.example.tld/js/embed.min.js"></script>
 
-    <section id="isso-thread"></section>
+    <section id="isso-thread">
+        <noscript>Javascript needs to be activated to view comments.</noscript>
+    </section>
 
 Note, that `data-isso` is optional, but when a website includes a script using
 ``async`` it is no longer possible to determine the script's external URL.

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,6 +61,6 @@
 
     <div class="demo">
         <h2>Demo</h2>
-        <section id="isso-thread"></section>
+        <section id="isso-thread"><noscript>Javascript needs to be activated to view comments.</noscript></section>
     </div>
 {% endblock %}

--- a/isso/demo/index.html
+++ b/isso/demo/index.html
@@ -10,7 +10,7 @@
 
 			<script	src="../js/embed.dev.js"></script>
 
-			<section id="isso-thread" data-title="Isso Test"></section>
+			<section id="isso-thread" data-title="Isso Test"><noscript>Javascript needs to be activated to view comments.</noscript></section>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
Add `<noscript>` tags with a warning that for comments to work, Javascript needs to be enabled.

If a browser has Javascript enabled (as almost all modern browsers do by default), the tags will be invisible to the user.