### PR TITLE
contrib: import_blogger: Warn on missing feedparser, run flake8 in contrib/ as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ init:
 	npm install
 
 flakes:
-	flake8 isso/ --count --max-line-length=127 --show-source --statistics
+	flake8 isso/ contrib/ --count --max-line-length=127 --show-source --statistics
 
 # Note: It doesn't make sense to split up configs by output file with
 # webpack, just run everything at once

--- a/contrib/import_blogger.py
+++ b/contrib/import_blogger.py
@@ -23,9 +23,16 @@ can then be fed into isso:
 """
 
 import json
-
-import feedparser
 import time
+
+try:
+    import feedparser
+except ImportError:
+    print("Error: Package feedparser not installed! You can install it via "
+          "'pip install feedparser' inside your virtualenv.")
+    import sys
+    sys.exit(1)
+
 from urllib.parse import urlparse
 
 


### PR DESCRIPTION
- `contrib: import_blogger: Warn on missing feedparser`
- `Makefile: Run flake8 on contrib/ folder, too`
