### PR TITLE
isso: js: embed: Insert Postbox before comments

### DIFF
--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -62,7 +62,8 @@ function fetchComments() {
         return;
     }
 
-    $('#isso-root').textContent = '';
+    var isso_root = $('#isso-root');
+    isso_root.textContent = '';
     api.fetch(isso_thread.getAttribute("data-isso-id") || location.pathname,
         config["max-comments-top"],
         config["max-comments-nested"]).then(
@@ -77,8 +78,9 @@ function fetchComments() {
                 config[setting] = rv.config[setting]
             }
 
-            // Finally, create Postbox with configs fetched from server
-            isso_thread.append(new isso.Postbox(null));
+            // Note: isso.Postbox relies on the config object populated by elements
+            // fetched from the server, so it cannot be created in init()
+            isso_root.prepend(new isso.Postbox(null));
 
             if (rv.total_replies === 0) {
                 heading.textContent = i18n.translate("no-comments");


### PR DESCRIPTION
This restores the behavior before #311

Closes https://github.com/posativ/isso/issues/815

Note: This is only a hotfix!

### Issue
We should revisit the way the client code constructs the core postbox and comment elements since we're now much more dependent on the calls to fetch config from the server before rendering anything.
[This piece of documentation](https://github.com/posativ/isso/blob/13b8df02c96392db1195db2e713e6f47b06dcd7e/docs/docs/extras/advanced-integration.rst#asynchronous-comments-loading) is also no longer 100% accurate.