### PR TITLE
docs: Check in rendered SCSS

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Installing Dependencies
-        run: sudo apt install python3-sphinx sassc
+        run: sudo apt install python3-sphinx
 
       - name: Check docs
         # TODO: -W turns warnings into errors

--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,6 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-# Generated CSS from SASS
-/docs/_static/css/site.css
 
 # PyBuilder
 target/

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ man: $(DOCS_RST_SRC)
 ${DOCS_CSS_DST}: $(DOCS_CSS_SRC) $(DOCS_CSS_DEP)
 	$(SASS) $(DOCS_CSS_SRC) $@
 
-${DOCS_HTML_DST}: $(DOCS_RST_SRC) $(DOCS_CSS_DST)
+${DOCS_HTML_DST}: $(DOCS_RST_SRC)
 	sphinx-build -b dirhtml docs/ $@
 
 site: $(DOCS_HTML_DST)
@@ -76,7 +76,7 @@ test: $($ISSO_PY_SRC)
 	pytest --doctest-modules isso/
 
 clean:
-	rm -f $(DOCS_MAN_DST) $(DOCS_CSS_DST) $(ISSO_JS_DST)
+	rm -f $(DOCS_MAN_DST) $(ISSO_JS_DST)
 	rm -rf $(DOCS_HTML_DST)
 
 .PHONY: clean site man init js coverage test

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -1,0 +1,316 @@
+@charset "UTF-8";
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box; }
+
+* {
+  margin: 0;
+  padding: 0; }
+
+html, body {
+  height: 100%; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: normal;
+  font-style: normal; }
+
+body {
+  font: 14px "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: black; }
+
+.wrapper {
+  min-height: 100%;
+  height: auto !important;
+  height: 100%;
+  margin: 0 auto -2em; }
+
+.push, .footer {
+  height: 2em; }
+  .push a, .push a:visited, .footer a, .footer a:visited {
+    color: #00aac2;
+    text-decoration: none; }
+
+.header {
+  *zoom: 1;
+  max-width: 68em;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 1em;
+  padding-bottom: 1em; }
+  .header:before, .header:after {
+    content: " ";
+    display: table; }
+  .header:after {
+    clear: both; }
+  .header a, .header a:visited {
+    color: #4d4c4c;
+    text-decoration: none; }
+  .header header {
+    display: block;
+    float: left;
+    margin-right: 16.0363113405%;
+    width: 41.9818443298%;
+    font-weight: normal; }
+    .header header:last-child {
+      margin-right: 0; }
+    .header header .logo {
+      max-height: 60px;
+      padding-right: 12px;
+      float: left; }
+    .header header h1 {
+      font-size: 1.55em;
+      margin-bottom: 0.3em; }
+    .header header h2 {
+      font-size: 1.05em; }
+  .header nav {
+    display: block;
+    float: left;
+    margin-right: 16.0363113405%;
+    width: 41.9818443298%; }
+    .header nav:last-child {
+      margin-right: 0; }
+    .header nav ul {
+      padding-top: 1.85em; }
+      .header nav ul li {
+        display: block;
+        float: right;
+        margin-left: 2em;
+        font-weight: 300;
+        text-transform: uppercase;
+        color: #444;
+        letter-spacing: 0.05em; }
+
+.outer {
+  background-color: #eeeeee;
+  box-shadow: inset 0 0 0.5em #c0c0c0; }
+  .outer header {
+    *zoom: 1;
+    max-width: 68em;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1em 0; }
+    .outer header:before, .outer header:after {
+      content: " ";
+      display: table; }
+    .outer header:after {
+      clear: both; }
+    .outer header h1 {
+      color: #555;
+      font: 300 35px Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      text-shadow: 1px 0 #c0c0c0;
+      letter-spacing: 0.05em; }
+  .outer footer {
+    *zoom: 1;
+    max-width: 68em;
+    margin-left: auto;
+    margin-right: auto; }
+    .outer footer:before, .outer footer:after {
+      content: " ";
+      display: table; }
+    .outer footer:after {
+      clear: both; }
+  .outer .index {
+    *zoom: 1;
+    max-width: 68em;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1em; }
+    .outer .index:before, .outer .index:after {
+      content: " ";
+      display: table; }
+    .outer .index:after {
+      clear: both; }
+    .outer .index figure {
+      display: block;
+      float: left;
+      margin-right: 5.8515051827%;
+      width: 36.4890968904%;
+      text-align: center;
+      max-width: 300px; }
+      .outer .index figure:last-child {
+        margin-right: 0; }
+      .outer .index figure img {
+        max-width: 100%;
+        max-height: 100%; }
+    .outer .index ul {
+      display: block;
+      float: left;
+      margin-right: 5.8515051827%;
+      width: 57.6593979269%;
+      margin-top: 1em; }
+      .outer .index ul:last-child {
+        margin-right: 0; }
+      .outer .index ul li {
+        list-style-type: none;
+        margin-bottom: 2em; }
+        .outer .index ul li strong {
+          font-weight: normal;
+          font-size: 18px;
+          color: black; }
+        .outer .index ul li p {
+          color: #5c5c5c; }
+        .outer .index ul li p + p {
+          margin-top: 0.5em; }
+
+.footer {
+  text-align: right;
+  padding: 0.5em 0; }
+
+main {
+  *zoom: 1;
+  max-width: 68em;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 1.6em;
+  margin-bottom: 2em;
+  line-height: 1.6em; }
+  main:before, main:after {
+    content: " ";
+    display: table; }
+  main:after {
+    clear: both; }
+  main h2:before {
+    content: "» "; }
+  main .links {
+    display: block;
+    float: left;
+    margin-right: 10.1483979942%;
+    width: 26.5677346705%; }
+    main .links:last-child {
+      margin-right: 0; }
+    main .links h2 {
+      margin-bottom: 1em;
+      margin-top: 1em; }
+    main .links > h2:first-child {
+      margin-top: 0; }
+    main .links p + p {
+      margin-top: 1em; }
+    main .links p + p:last-child {
+      margin-top: 0; }
+    main .links li {
+      list-style-type: none; }
+    main .links .search input {
+      padding: 0.1em 0.4em; }
+  main .demo {
+    display: block;
+    float: left;
+    margin-right: 10.1483979942%;
+    width: 63.2838673353%; }
+    main .demo:last-child {
+      margin-right: 0; }
+    main .demo h2 {
+      margin-bottom: 1em; }
+    main .demo h4 {
+      margin-bottom: 0.5em; }
+    main .demo blockquote {
+      margin-top: 10px;
+      margin-bottom: 10px;
+      padding-left: 15px;
+      border-left: 3px solid #ccc; }
+    main .demo pre {
+      background: #eee;
+      border: 1px solid #ddd;
+      padding: 10px 15px;
+      color: #4d4d4c;
+      overflow: auto; }
+  main .sidebar {
+    display: block;
+    float: left;
+    margin-right: 5.8515051827%;
+    width: 15.3187958539%;
+    display: block; }
+    main .sidebar:last-child {
+      margin-right: 0; }
+    main .sidebar strong {
+      color: #00aac2;
+      font-weight: bold;
+      text-transform: uppercase; }
+    main .sidebar ul {
+      margin-top: 0.5em;
+      margin-bottom: 1em; }
+    main .sidebar ul:last-child {
+      margin-bottom: 0; }
+    main .sidebar li {
+      border-left: solid 2px #d3d3d3;
+      margin-left: 0.25em;
+      padding-left: 0.75em;
+      padding-top: 0.25em;
+      padding-bottom: 0.25em;
+      font-weight: 300;
+      list-style-type: none; }
+      main .sidebar li a {
+        color: #5c5c5c; }
+    main .sidebar .active {
+      border-left-color: #00aac2; }
+      main .sidebar .active a {
+        color: #00aac2;
+        font-weight: bold; }
+  main .docs {
+    display: block;
+    float: left;
+    margin-right: 5.8515051827%;
+    width: 78.8296989635%;
+    font-size: 15px;
+    color: #5c5c5c; }
+    main .docs:last-child {
+      margin-right: 0; }
+    main .docs h2, main .docs h3, main .docs h4 {
+      margin-top: 1em;
+      margin-bottom: 1em; }
+    main .docs h2 {
+      font-size: 24px; }
+    main .docs h3 {
+      font-size: 18px; }
+    main .docs h4 {
+      font-size: 14px; }
+    main .docs pre, main .docs code {
+      color: #4d4d4c;
+      font-size: 12px;
+      font-family: Monaco, Menlo, Consolas, monospace; }
+    main .docs code {
+      background-color: #eeeeee;
+      padding: 0.2em 0.3em; }
+    main .docs .highlight {
+      margin: 1.2em 0;
+      padding: 10px 15px;
+      background-color: #eeeeee;
+      color: #4d4d4c;
+      border: 1px solid #dddddd;
+      border-radius: 4px;
+      overflow: auto; }
+    main .docs .headerlink {
+      visibility: hidden; }
+    main .docs p + p {
+      margin-top: 1em; }
+    main .docs p + p:last-child {
+      margin-bottom: 0; }
+    main .docs blockquote {
+      margin: 1em;
+      text-align: center;
+      font-size: 125%;
+      font-style: italic; }
+    main .docs blockquote:before {
+      content: "» "; }
+    main .docs blockquote:after {
+      content: " «"; }
+    main .docs ul {
+      margin: 1em 0; }
+      main .docs ul li {
+        list-style-type: square;
+        margin-left: 2em;
+        margin-right: 2em; }
+  main a {
+    text-decoration: none;
+    color: #00aac2; }
+  main dt {
+    font-weight: bold;
+    margin: 0.4em 0; }
+  main dd {
+    margin-left: 1.2em; }
+  main dl {
+    margin-bottom: 0.4em; }
+  main .admonition p + p {
+    margin-top: 0.25em; }
+  main .admonition p:not(:first-child) {
+    margin-left: 2em; }


### PR DESCRIPTION
No one has touched those css files in years, and by removing `sassc` as a dependency, we can cut down some build time and setup complexity.

Also remove from GitHub Actions.