### PR TITLE
Bugfix/gravatar display avatar size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Changelog for Isso
   This change necessitates adjusting custom CSS files to the new names.
 - Drop support for outdated Python version 3.5
   (#808, l33tname)
+- Fix avatar sizing, limit default gravatar images to 55px (#831, l33tname)
+  In case of a custom gravatar URL, the ``&s=55`` size parameter will have
+  to be added, see `Gravatar: Image requests`_.
+
+.. _Gravatar: Image requests: http://en.gravatar.com/site/implement/images/
 
 0.12.6 (2022-03-06)
 -------------------

--- a/docs/docs/configuration/server.rst
+++ b/docs/docs/configuration/server.rst
@@ -107,7 +107,7 @@ gravatar
 
 gravatar-url
     Url for gravatar images. The "{}" is where the email hash will be placed.
-    Defaults to "https://www.gravatar.com/avatar/{}?d=identicon"
+    Defaults to "https://www.gravatar.com/avatar/{}?d=identicon&s=55"
 
 latest-enabled
     If True it will enable the ``/latest`` endpoint. Optional, defaults

--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -47,7 +47,6 @@
 .isso-comment > .isso-avatar {
     display: block;
     float: left;
-    width: 7%;
     margin: 3px 15px 0 0;
 }
 .isso-comment > .isso-avatar > svg {

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -57,6 +57,8 @@ log-file =
 gravatar = false
 
 # default url for gravatar. {} is where the hash will be placed
+# `s=55` results in height and width of 55px.
+# for other options, see http://en.gravatar.com/site/implement/images/
 gravatar-url = https://www.gravatar.com/avatar/{}?d=identicon&s=55
 
 # enable the "/latest" endpoint, that serves comment for multiple posts (not 

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -57,7 +57,7 @@ log-file =
 gravatar = false
 
 # default url for gravatar. {} is where the hash will be placed
-gravatar-url = https://www.gravatar.com/avatar/{}?d=identicon
+gravatar-url = https://www.gravatar.com/avatar/{}?d=identicon&s=55
 
 # enable the "/latest" endpoint, that serves comment for multiple posts (not 
 # needing to previously know the posts URIs)


### PR DESCRIPTION
* Fix display for larger avatar images
* limit default gravatar images to the same 55px as the non gravatar images

I didn't see any negative effects of removing the 7% with but idk i guess it was there for a reason
![Screenshot 2022-03-27 at 20-54-21 Binärgewitter Talk #292 USB Autobatterie](https://user-images.githubusercontent.com/1682954/160296681-197b308d-2359-4c9a-b876-21d409f0315c.png)
![Screenshot 2022-03-27 at 20-53-51 Binärgewitter Talk #292 USB Autobatterie](https://user-images.githubusercontent.com/1682954/160296682-cdf5ca31-f7d2-49cb-bce8-fd5c3dadbd3c.png)

