### PR TITLE
Removes reference to unmaintained yaourt

### DIFF
--- a/docs/docs/install.rst
+++ b/docs/docs/install.rst
@@ -140,7 +140,6 @@ Prebuilt Packages
   – not yet available in Portage, but you can use the ebuild to build Isso.
 
 * Arch Linux: https://aur.archlinux.org/packages/isso/
-  – install with `yaourt isso`.
 
 * Fedora: https://copr.fedoraproject.org/coprs/jujens/isso/ — copr
   repository. Built from Pypi, includes a systemctl unit script.


### PR DESCRIPTION
The AUR helper yaourt has been unmaintained for years, has bugs and is probably not compatible with the current version of pacman. Yaourt should therefore no longer be used.

Since there are many alternative AUR helpers and an installation is also possible without such a tool, I think we should not give an installation example.