### PR TITLE
js: isso: Fix class selector for preview

### DIFF
--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -94,7 +94,7 @@ var Postbox = function(parent) {
     $("[name='preview']", el).on("click", function() {
         api.preview(utils.text($(".isso-textarea", el).innerHTML)).then(
             function(html) {
-                $(".preview .text", el).innerHTML = html;
+                $(".isso-preview .isso-text", el).innerHTML = html;
                 el.classList.add('isso-preview-mode');
             });
     });


### PR DESCRIPTION
The selector also needs the `isso-` prefix, else the DOM selection fails and the subsequent code gets a null obj, which then fails.

This was overlooked in 85f3954c80bc68feb0de23c186d06c716016faae
"js: app/isso: Prefix localstorage keys w/ isso-"

Fixes https://github.com/posativ/isso/issues/839