### PR TITLE
Dockerfile: Use Alpine base images, optimize process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,87 @@
-# First, compile JS stuff
-FROM node:dubnium-buster AS jsBuilder
+# Isso production Dockerfile
+
+# First stage: Build Javascript client parts using NodeJS
+
+FROM node:current-alpine AS isso-js
 WORKDIR /src/
-COPY . .
+
+# make is not installed by default on alpine
+RUN apk add --no-cache make
+
+# Only copy necessities, to not trigger re-builds unnecessarily
+COPY ["Makefile", "package.json", "package-lock.json", "./"]
+COPY ["isso/js/", "./isso/js/"]
+COPY ["isso/css/", "./isso/css/"]
+
+# Disable nagware and save some time skipping "security" "audits"
+RUN echo -e "audit=false\nfund=false"> /root/.npmrc
+
 RUN make init js
 
-# Second, create virtualenv
-FROM python:3.8-buster AS venvBuilder
-WORKDIR /src/
-# Set TOX_ENV_NAME in order for the "build_py" command in setup.py to skip
-# building Javascript artifacts as they have already been created by the
-# "jsBuilder" step.
-ENV TOX_ENV_NAME=1
-COPY --from=jsBuilder /src .
+# Second stage: Create production-ready Isso package
+
+# Copy needed files
+FROM python:3.10-alpine AS isso-builder
+WORKDIR /isso/
+
+# Set up virtualenv
 RUN python3 -m venv /isso \
  && . /isso/bin/activate \
  && pip3 install --no-cache-dir --upgrade pip \
- && pip3 install --no-cache-dir gunicorn flask \
- && python setup.py install \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ && pip3 install --no-cache-dir gunicorn
 
-# Third, create final repository
-FROM python:3.8-slim-buster
+# Install cffi dependencies since they're not present on alpine by default
+# (required by cffi which in turn is required by misaka)
+RUN apk add --no-cache gcc libffi-dev libc-dev
+
+# For some reason, it is required to install cffi before misaka, else pip will
+# fail to build cffi
+RUN . /isso/bin/activate \
+ && pip3 install cffi
+
+# Install Isso's python dependencies via pip in a separate step before copying
+# over client files, so that changing Isso js/python source code will not
+# trigger a re-installation of all pip packages from scratch
+COPY ["setup.py", "setup.cfg", "README.md", "LICENSE", "./"]
+RUN . /isso/bin/activate \
+ && python3 setup.py develop
+
+# Then copy over files
+# SRC "isso/" is treated as "isso/*" by docker, so copy to subdir explicitly
+COPY ["./isso/", "/isso/isso/"]
+COPY ["./share/", "./share/"]
+
+# Copy over generated Javascript client files
+COPY --from=isso-js /src/isso/js/ ./isso/js
+
+# Build and install Isso package (pip dependencies cached from previous step)
+RUN . /isso/bin/activate \
+ && python3 setup.py develop --no-deps
+
+
+# Third stage: Run Isso
+FROM python:3.10-alpine AS isso
 WORKDIR /isso/
-COPY --from=venvBuilder /isso .
+COPY --from=isso-builder /isso/ .
+
+# Clean up
+RUN rm -rf /var/apk/cache/* /tmp/* /var/tmp/*
 
 # Configuration
 VOLUME /db /config
 EXPOSE 8080
 ENV ISSO_SETTINGS /config/isso.cfg
+
+# Run Isso via gunicorn WSGI server
 CMD ["/isso/bin/gunicorn", "-b", "0.0.0.0:8080", "-w", "4", "--preload", "isso.run", "--worker-tmp-dir", "/dev/shm"]
 
 # Example of use:
 #
-# docker build -t isso .
-# docker run -it --rm -v /opt/isso:/config -v /opt/isso:/db -v $PWD:$PWD isso /isso/bin/isso -c \$ISSO_SETTINGS import disqus.xml
-# docker run -d --rm --name isso -p 8080:8080 -v /opt/isso:/config -v /opt/isso:/db isso
+# Build:
+# $ docker build -t isso .
+#
+# Run:
+# $ mkdir config
+# $ cp share/isso-dev.conf config/isso.cfg
+# $ mkdir db/
+# $ docker run -d --rm --name isso -p 8080:8080 -v $PWD/config:/config -v $PWD/db:/db isso:latest


### PR DESCRIPTION
The [current `Dockerfile`](https://github.com/posativ/isso/blob/master/Dockerfile#L2) uses an outdated version of Debian which ships versions of `node` and `npm` that incompatible with some of the packages Isso requires.

Issues reported in https://github.com/posativ/isso/issues/836

Fix this by using newer base images which ship the required node/npm versions. As a side benefit, Alpine Linux images are smaller, thus resulting in faster build times (less time required to pull) and a smaller generated docker image for Isso.