### PR TITLE
[client] js: Support enabling reply notifications checkbox by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changelog for Isso
 - Fix avatar sizing, limit default gravatar images to 55px (#831, l33tname)
   In case of a custom gravatar URL, the ``&s=55`` size parameter will have
   to be added, see `Gravatar: Image requests`_.
+- Add ``data-isso-reply-notifications-default-enabled`` option to configure
+  whether or not the subscribe to replies checkbox should be checked by default.
 
 .. _Gravatar: Image requests: http://en.gravatar.com/site/implement/images/
 

--- a/docs/docs/reference/client-config.rst
+++ b/docs/docs/reference/client-config.rst
@@ -20,6 +20,7 @@ preferably in the script tag which embeds the JS:
             data-isso-vote="true"
             data-isso-vote-levels=""
             data-isso-feed="false"
+            data-isso-reply-notifications-default-enabled="false"
             src="/prefix/js/embed.js"></script>
 
 Furthermore you can override the automatic title detection inside
@@ -141,6 +142,18 @@ data-isso-feed
     Enable or disable the addition of a link to the feed for the comment
     thread. The link will only be valid if the appropriate setting, in
     ``[rss]`` section, is also enabled server-side.
+
+data-isso-reply-notifications-default-enabled
+    Set to ``true`` to make the reply notifications checkbox on the postbox be
+    checked by default. Otherwise, the user will have to manually opt-in to
+    reply notifications.
+
+    This setting will have no effect if ``reply-notifications`` are not enabled
+    on the server.
+
+    Default: ``false``
+
+    .. versionadded:: 0.13
 
 
 Deprecated Client Settings

--- a/isso/js/app/config.js
+++ b/isso/js/app/config.js
@@ -11,6 +11,7 @@ var config = {
     "require-email": false,
     "require-author": false,
     "reply-notifications": false,
+    "reply-notifications-default-enabled": false,
     "max-comments-top": "inf",
     "max-comments-nested": 5,
     "reveal-on-click": 5,

--- a/isso/js/app/templates/postbox.js
+++ b/isso/js/app/templates/postbox.js
@@ -1,8 +1,10 @@
 var html = function (globals) {
   var i18n = globals.i18n;
+  var conf = globals.conf;
   var author = globals.author;
   var email = globals.email;
   var website = globals.website;
+  var notify = conf["reply-notifications-default-enabled"] ? " checked" : '';
 
   return "" +
 "<div class='isso-postbox'>"
@@ -39,7 +41,7 @@ var html = function (globals) {
   + "</section>"
   + "<section class='isso-notification-section'>"
     + "<label>"
-      + "<input type='checkbox' name='notification' />" + i18n('postbox-notification')
+      + "<input type='checkbox'" + notify + " name='notification' />" + i18n('postbox-notification')
     + "</label>"
   + "</section>"
 + "</div>"

--- a/isso/js/tests/unit/postbox-reply-notif.test.js
+++ b/isso/js/tests/unit/postbox-reply-notif.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* Keep the above exactly as-is!
+ * https://jestjs.io/docs/configuration#testenvironment-string
+ * https://jestjs.io/docs/configuration#testenvironmentoptions-object
+ */
+
+"use strict";
+
+// Set up our document body
+document.body.innerHTML =
+  '<div id=isso-thread></div>' +
+  '<script ' +
+    'src="http://isso.api/js/embed.min.js" ' +
+    'data-isso="/" ' +
+    '></script>';
+
+const isso = require("app/isso");
+const $ = require("app/dom");
+const config = require("app/config");
+const i18n = require("app/i18n");
+const template = require("app/template");
+template.set("conf", config);
+template.set("i18n", i18n.translate);
+
+test('Create Postbox with reply notifications disabled by default', () => {
+  var isso_thread = $('#isso-thread');
+  isso_thread.append('<div id="isso-root"></div>');
+  isso_thread.append(new isso.Postbox(null));
+
+  expect($('.isso-notification-section input[type="checkbox"]',
+           isso_thread).checked).toBeFalse;
+});
+
+test('Create Postbox with reply notifications enabled by default', () => {
+  var script_tag = document.getElementsByTagName('script')[0];
+  script_tag.setAttribute('data-isso-reply-notifications-default-enabled', 'true');
+
+  var isso_thread = $('#isso-thread');
+  isso_thread.append('<div id="isso-root"></div>');
+  isso_thread.append(new isso.Postbox(null));
+
+  expect($('.isso-notification-section input[type="checkbox"]',
+           isso_thread).checked).toBeTrue;
+});


### PR DESCRIPTION
Fixes #837 

Configure by setting `data-isso-reply-notifications-default-enabled` to `"true"` in the client settings. If set to true, then the checkbox for enabling reply notifications will be checked by default:

![the checkbox is checked](https://user-images.githubusercontent.com/17971474/165186013-6f78a285-545c-4c8e-83a4-ad9ae3735274.png)