### PR TITLE
[ci] [docker] Use docker for e2e, client testing, add docker-compose file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Files that should not be sent to the docker daemon when building
+# Docker will have its own cache of node packages and its own python venv
+node_modules/
+.venv/

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -1,0 +1,36 @@
+name: E2e tests with docker
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build the stack
+        run: |
+          docker compose build isso-js-puppeteer-intermediary
+          docker compose build isso-server
+          docker compose build isso-client
+
+      - name: Bring up containers
+        run: docker compose up -d
+
+      - name: Client unit tests
+        run: |
+          docker run \
+          --mount type=bind,source=${{ github.workspace }}/package.json,target=/src/package.json,readonly \
+          --mount type=bind,source=${{ github.workspace }}/isso/js/,target=/src/isso/js/,readonly \
+          isso-js-testbed npm run test-unit
+
+      - name: Client integration tests
+        run: |
+          docker run \
+          --mount type=bind,source=${{ github.workspace }}/package.json,target=/src/package.json,readonly \
+          --mount type=bind,source=${{ github.workspace }}/isso/js/,target=/src/isso/js/,readonly \
+          --env ISSO_ENDPOINT='http://isso-dev.local:8080' \
+          --network container:isso-server \
+          isso-js-testbed npm run test-integration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+# https://docs.docker.com/compose/compose-file/compose-file-v3/
+version: "3.9"
+
+services:
+
+  # Force building intermediate image
+  isso-js-puppeteer-intermediary:
+    image: isso-js-puppeteer
+    container_name: isso-js-puppeteer-intermediary
+    build:
+      context: .
+      dockerfile: docker/Dockerfile-js-puppeteer
+
+  # Isso server should always reflect production image
+  isso-server:
+    image: isso
+    container_name: isso-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # No need to set entrypoint, image already provides CMD
+    #command: /isso/bin/isso -c /config/isso.cfg run
+    environment:
+      ISSO_SETTINGS: "/config/isso-dev.cfg"
+    # If needed, production docker image can also be exposed for non-docker
+    # unit/integration testing
+    #ports:
+    #  - 127.0.0.1:8080:8080
+    expose:
+      - 8080
+    networks:
+      test-net:
+        # Also make available under http://isso-dev.local and localhost:
+        aliases:
+        - isso-dev.local
+        - localhost
+    volumes:
+      - ./db:/db/
+      - type: bind
+        source: ./share/isso-dev.cfg
+        target: /config/isso-dev.cfg
+        volume:
+          nocopy: true
+
+  # Jest and puppeteer end-to-end integration test runner
+  isso-client:
+    image: isso-js-testbed
+    container_name: isso-client
+    build:
+      context: .
+      dockerfile: docker/Dockerfile-js-testbed
+    environment:
+      ISSO_ENDPOINT: "http://isso-dev.local:8080"
+    # Command may also run from outside docker compose, e.g.:
+    # $ docker run isso-js-testbed [mount, networks, ...] npm run test-integration
+    #command: npm run test-integration
+    networks:
+      - test-net
+    # Bind-mounts, see:
+    # https://docs.docker.com/compose/compose-file/compose-file-v3/#long-syntax-3
+    volumes:
+      - type: bind
+        source: ./package.json
+        target: /src/package.json
+        volume:
+          nocopy: true
+      - type: bind
+        source: ./isso/js/
+        target: /src/isso/js/
+        volume:
+          nocopy: true
+    depends_on:
+      - isso-server
+      - isso-js-puppeteer-intermediary
+
+networks:
+  test-net:

--- a/docker/Dockerfile-js-puppeteer
+++ b/docker/Dockerfile-js-puppeteer
@@ -1,0 +1,19 @@
+# Download puppeteer assets
+# This image should be tagged as "isso-js-puppeteer"
+
+# Avoid triggering a re-download of its puppeteer assets if at all possible
+
+# Note: Keep (alpine) base image in sync with other dockerfiles to avoid
+# duplication
+FROM docker.io/node:current AS isso-js-puppeteer
+WORKDIR /src/
+
+# Installing puppeteer will take some time as it pulls in
+# a ~400Mb headless chrome file
+RUN npm install puppeteer
+
+# Example of use:
+#
+# docker build -f docker/Dockerfile-js-puppeteer -t isso-js-puppeteer .
+
+# vim: set filetype=dockerfile

--- a/docker/Dockerfile-js-testbed
+++ b/docker/Dockerfile-js-testbed
@@ -1,0 +1,36 @@
+# Prepare a testbed for Javascript testing
+# This image should be tagged as "isso-js-testbed"
+
+# Note: Do not use alpine images as they do not contain needed GObject, X11
+# etc. packages and complicate things
+# :current resolves to NodeJS 17 on Debian Buster as of 03/2022
+# https://hub.docker.com/_/node
+FROM docker.io/node:current AS isso-js-testbed
+WORKDIR /src/
+
+# Install everything necessary to run headless
+RUN apt-get update && apt-get install -y --no-install-recommends libnss3 libxss1 chromium
+
+# Skip downloading headless chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+RUN npm install --no-save jest jest-puppeteer jest-environment-jsdom
+
+# Restore headless chromium files from intermediate image
+COPY --from=isso-js-puppeteer \
+    /src/node_modules/puppeteer/.local-chromium/ \
+    ./node_modules/puppeteer/.local-chromium/
+
+# Need to set $CI so that jest-puppeteer applies sensible launch params for
+# running headless chromium. Otherwise, chromium will fail with a "missing
+# sandbox" error.
+# https://github.com/smooth-code/jest-puppeteer/blob/678ce56b49100f248237757df19f89b2542a9465/packages/jest-environment-puppeteer/src/readConfig.js#L14-L28
+ENV CI=true
+
+# Note: No entry point, will be set by docker-compose
+
+# Example of use:
+#
+# docker build -f docker/Dockerfile-js-testbed -t isso-js-testbed .
+
+# vim: set filetype=dockerfile


### PR DESCRIPTION
### .github: docker-compose action for e2e, unit testing

This will run e2e tests on every push and PR.

### Add docker-compose.yml for e2e testing

To be used with:
```sh
$ docker compose build [images...]
$ docker compose up -d
```

Documentation to follow.

### Add Dockerfiles for e2e js testing

One base image containing downloaded puppeteer chromium
binary (~400Mb), one testbed image to run the actual tests

### Add .dockerignore; ignore node_modules, .venv

This will speed up docker builds as the "build context" to
send to the daemon is now smaller.
