### PR TITLE
docs: theme: Rework sidebar internals, fix search, error-on-warn, minor

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,5 +34,4 @@ jobs:
         run: pip install -r sphinx-requirements.txt
 
       - name: Check docs
-        # TODO: -W turns warnings into errors
         run: make site

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,9 @@ css: $(DOCS_CSS_DST)
 ${DOCS_CSS_DST}: $(DOCS_CSS_SRC) $(DOCS_CSS_DEP)
 	$(SASS) $(DOCS_CSS_SRC) $@
 
+# Sphinx: "-W" flag turns warnings into errors, can be disabled for debugging
 ${DOCS_HTML_DST}: $(DOCS_RST_SRC) $(DOCS_CSS_DST)
-	sphinx-build -b dirhtml docs/ $@
+	sphinx-build -b dirhtml -W docs/ $@
 
 site: $(DOCS_HTML_DST)
 

--- a/docs/_isso/layout.html
+++ b/docs/_isso/layout.html
@@ -1,5 +1,20 @@
 <!DOCTYPE html>
 
+{%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and
+                         (sidebars != []) %}
+
+{%- macro sidebar() %}
+      {%- if render_sidebar %}
+          {%- if sidebars != None %}
+          <div role="navigation" class="sidebar">
+            {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+            {%- endfor %}
+          </div>
+          {%- endif %}
+      {%- endif %}
+{%- endmacro %}
+
 {%- macro script() %}
     {%- for js in script_files %}
     {{ js_tag(js) }}
@@ -14,6 +29,14 @@
     <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
       {%- endif %}
     {%- endfor %}
+{%- endmacro %}
+
+{%- macro vcs_edit_link() %}
+{%- if hasdoc(pagename) and display_github %}
+<div class="vcs-edit-container">
+<a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix or ".html" }}" class="vcs-edit"><img src="{{ pathto('_static/github.svg', 1) }}" /> Edit on GitHub</a>
+</div>
+{%- endif %}
 {%- endmacro %}
 
 <html>
@@ -52,7 +75,6 @@
     <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
     {%- endif %}
 {%- endblock %}
-{%- block extrahead %} {% endblock %}
 </head>
 <body>
     <div class="wrapper">
@@ -80,7 +102,19 @@
 
 
         <main>
-        {% block body %} {% endblock %}
+        {% block main %}
+            {{ sidebar() }}
+
+            <div class="docs">
+                {{ vcs_edit_link() }}
+
+                <div role="main">
+                {% block body %}
+                {{ body }}
+                {% endblock %}
+                </div>
+            </div>
+        {% endblock %}
         </main>
 
         <div class="push"></div>

--- a/docs/_isso/page.html
+++ b/docs/_isso/page.html
@@ -4,18 +4,3 @@
         <h1>{{- title -}}</h1>
     </header>
 {% endblock %}
-{% block body %}
-    <div class="sidebar">
-    {% if pagename.startswith("docs/") %}
-        {% include "sidebar-docs.html" %}
-    {% endif %}
-    </div>
-    <div class="docs">
-          {%- if hasdoc(pagename) and display_github %}
-          <div class="vcs-edit-container">
-          <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix or ".html" }}" class="vcs-edit"><img src="{{ pathto('_static/github.svg', 1) }}" /> Edit on GitHub</a>
-          </div>
-          {%- endif %}
-        {{ body }}
-    </div>
-{% endblock %}

--- a/docs/_isso/search.html
+++ b/docs/_isso/search.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] + ['_static/language_data.js'] %}
-{% block extrahead %}
+{% block footer %}
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
   </script>
@@ -15,14 +15,16 @@
   <script type="text/javascript" id="searchindexloader"></script>
   {{ super() }}
 {% endblock %}
-{% block body %}
+{% block main %}
+<div class="docs">
+  <noscript>
   <div id="fallback" class="admonition warning">
-  <script type="text/javascript">$('#fallback').hide();</script>
-  <p>
-    {% trans %}Please activate JavaScript to enable the search
-    functionality.{% endtrans %}
-  </p>
+    <p class="last">
+      {% trans trimmed %}Please activate JavaScript to enable the search
+      functionality.{% endtrans %}
+    </p>
   </div>
+  </noscript>
   <p>
     {% trans %}From here you can search these documents. Enter your search
     words into the box below and click "search". Note that the search
@@ -51,4 +53,5 @@
     </ul>
   {% endif %}
   </div>
+</div>
 {% endblock %}

--- a/docs/_isso/searchbox.html
+++ b/docs/_isso/searchbox.html
@@ -1,12 +1,18 @@
 {%- if pagename != "search" %}
-<div id="searchbox" style="display: none">
+<div role="search" id="searchbox" style="display: none">
   <h2>{{ _('Quick search') }}</h2>
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="{{ _('Go') }}" />
+      <input type="text"
+             name="q"
+             aria-labelledby="searchlabel"
+             autocomplete="off"
+             autocorrect="off"
+             autocapitalize="off"
+             spellcheck="false"
+      />
       <input type="hidden" name="check_keywords" value="yes" />
       <input type="hidden" name="area" value="default" />
     </form>
 </div>
-<script type="text/javascript">$('#searchbox').show(0);</script>
+<script>document.getElementById('searchbox').style.display = "block"</script>
 {%- endif %}

--- a/docs/_isso/sidebar-docs.html
+++ b/docs/_isso/sidebar-docs.html
@@ -1,11 +1,6 @@
-{% macro doc(path, title) %}
-    {%- if pagename == path -%}
-    <li class="active">
-    {% else %}
-    <li>
-    {%- endif -%}
-    <a href="{{ pathto(path) }}">{{ title }}</a></li>
-{% endmacro %}
+{%- block sidebarsearch %}
+{%- include "searchbox.html" %}
+{%- endblock %}
 
 {%- block menu %}
   {%- set toctree = toctree(maxdepth=theme_navigation_depth|int,
@@ -18,8 +13,4 @@
     <!-- Local TOC -->
     <div class="local-toc">{{ toc }}</div>
   {%- endif %}
-{%- endblock %}
-
-{%- block sidebarsearch %}
-{%- include "searchbox.html" %}
 {%- endblock %}

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -192,6 +192,11 @@ main {
       margin-top: 0; }
     main .links li {
       list-style-type: none; }
+  main .highlighted {
+    background: #f1c40f;
+    box-shadow: 0 0 0 2px #f1c40f;
+    font-weight: bold;
+    color: #2f2f2f; }
   main .search input {
     padding: 0.1em 0.4em;
     margin-top: 0.3em;
@@ -252,7 +257,8 @@ main {
         color: #00aac2;
         font-weight: bold; }
     main .sidebar #searchbox {
-      color: #2f2f2f; }
+      color: #2f2f2f;
+      margin: 0 0 1.4em; }
       main .sidebar #searchbox h2 {
         color: #00aac2;
         font-weight: bold;
@@ -316,15 +322,15 @@ main {
         list-style-type: square;
         margin-left: 2em;
         margin-right: 2em; }
-    main .docs .vcs-edit {
-      font-size: 1.16em;
-      line-height: 1.16em;
-      float: right; }
-      main .docs .vcs-edit img {
-        height: 20px;
-        width: 20px;
-        margin-right: 0.2em;
-        vertical-align: top; }
+  main .vcs-edit {
+    font-size: 1.16em;
+    line-height: 1.16em;
+    float: right; }
+    main .vcs-edit img {
+      height: 20px;
+      width: 20px;
+      margin-right: 0.2em;
+      vertical-align: top; }
   main a {
     text-decoration: none;
     color: #00aac2; }

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -8,6 +8,7 @@ $blue: #00aac2;
 $text: #2f2f2f;
 $muted-grey: #151515;
 $admon-todo: #f0b37e;
+$highlighted: #f1c40f;
 
 * {
   margin: 0;
@@ -202,6 +203,13 @@ main {
     }
   }
 
+  .highlighted {
+    background: $highlighted;
+    box-shadow: 0 0 0 2px $highlighted;
+    font-weight: bold;
+    color: $text;
+  }
+
   .search {
     input {
       padding: 0.1em 0.4em;
@@ -284,6 +292,7 @@ main {
 
     #searchbox {
       color: $text;
+      margin: 0 0 1.4em;
 
       h2 {
         color: $blue;
@@ -384,19 +393,19 @@ main {
         margin-right: 2em;
       }
     }
+  }
 
-    // "Edit on Github" link
-    .vcs-edit {
-        font-size: 1.16em;
-        line-height: 1.16em;
-        float: right;
-        & img {
-          height: 20px;
-          width: 20px;
-          margin-right: 0.2em;
-          vertical-align: top;
-        }
-    }
+  // "Edit on Github" link
+  .vcs-edit {
+      font-size: 1.16em;
+      line-height: 1.16em;
+      float: right;
+      & img {
+        height: 20px;
+        width: 20px;
+        margin-right: 0.2em;
+        vertical-align: top;
+      }
   }
 
   a {

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Community
 =========
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,13 @@ extensions = [
     'sphinx_reredirects',
 ]
 
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# These patterns also affect html_static_path and html_extra_path
+exclude_patterns = [
+    "releasing.rst",
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,6 +125,10 @@ html_theme_options = {
     #"titles_only": True,
 }
 
+# If true, the text around the keyword is shown as summary of each search result.
+# Default is True.
+html_show_search_summary = True
+
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ["."]
 
@@ -163,7 +167,13 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+html_sidebars = {
+    'docs/**': ['sidebar-docs.html'],
+    'index': [],
+    'news': [],
+    'community': [],
+    'search': [],
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/docs/index.rst
+++ b/docs/docs/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Overview
 ========
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
     </ul>
  </div>
 {% endblock %}
-{% block body %}
+{% block main %}
     <div class="links">
     <h2>Links</h2>
     <ul>

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 News
 ====
 

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Releasing steps
 ===============
 

--- a/docs/theme-testing.rst
+++ b/docs/theme-testing.rst
@@ -1,4 +1,4 @@
-.. hidden:
+:orphan:
 
 Theme testing page
 ==================


### PR DESCRIPTION
### [nit] Makefile: Throw error on sphinx warnings
(Such as missing table of contents entry)

### docs: theme: Rework sidebar internals, fix search

Search was showing no context around items, only titles. To fix this, a block with `role="main"` had to be introduced at the correct location.

While at it, also make the "Edit on GitHub" link a macro and fix associated styling.

### [nit] docs: Ignore releasing.rst file

Only meant for maintainers

### [nit] docs: Make pages not in TOC orphans

This gets rid of some warning pages. These pages are either included via the navbar or are not supposed to be rendered at all, so the warnings were superfluous.
