### PR TITLE
[server] isso/init: Log paths at start, error if not found; ISSO_SETTINGS takes precedence over -c flag

### DIFF
--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -242,7 +242,8 @@ def main():
 
     args = parser.parse_args()
 
-    conf_file = args.conf
+    # ISSO_SETTINGS env var takes precedence over `-c` flag
+    conf_file = os.environ.get('ISSO_SETTINGS') or args.conf
 
     if not conf_file:
         logger.error("No configuration file specified! Exiting.")


### PR DESCRIPTION
### isso/init: Log paths at start, error if not found

Fixes #585

### isso/init: ISSO_SETTINGS takes precedence over -c

This restores the behavior as was documented in the server config docs, i.e. makes it possible to use `ISSO_SETTINGS=share/isso-dev.cfg isso run`.
This used to fail as `ISSO_SETTINGS` was only read by WSGI invocations of `isso.dispatch` or `isso.run`

---

Ping @jwatt 