### PR TITLE
isso: migrate: Workaround empty Disqus ids/titles

### DIFF
--- a/isso/tests/disqus.xml
+++ b/isso/tests/disqus.xml
@@ -78,4 +78,39 @@
         <thread dsq:id="1337" />
     </post>
 
+    <!-- Empty thread title and thead id
+         reported by waqqasdadabhoy in https://github.com/posativ/isso/issues/728 -->
+    <thread dsq:id="7">
+        <id />
+        <forum>redacted</forum>
+        <category dsq:id="435915" />
+        <link>http://localhost:4000/blog/2013/02/12/redacted/index.html</link>
+        <title />
+        <message />
+        <createdAt>2013-02-12T16:29:45Z</createdAt>
+        <author>
+            <name>Redacted</name>
+            <isAnonymous>false</isAnonymous>
+            <username>redacted</username>
+        </author>
+        <isClosed>false</isClosed>
+        <isDeleted>false</isDeleted>
+    </thread>
+
+    <!-- reference to thread with empty id -->
+    <post dsq:id="8">
+        <message><![CDATA[<p>Message from thread with empty title and id</p>]]></message>
+        <createdAt>2013-10-11T06:51:33Z</createdAt>
+        <isDeleted>false</isDeleted>
+        <isSpam>false</isSpam>
+        <author>
+            <email>baz@email.foo</email>
+            <name>Empty</name>
+            <isAnonymous>false</isAnonymous>
+            <username>EmptyUsername</username>
+        </author>
+        <ipAddress>127.0.0.1</ipAddress>
+        <thread dsq:id="7" />
+    </post>
+
   </disqus>

--- a/isso/tests/test_migration.py
+++ b/isso/tests/test_migration.py
@@ -20,16 +20,43 @@ conf = config.new({
 
 class TestMigration(unittest.TestCase):
 
-    def test_disqus(self):
+    def test_disqus_empty_id(self):
+        """
+        Fails with empty thread id
+        """
 
         xml = join(dirname(__file__), "disqus.xml")
         xxx = tempfile.NamedTemporaryFile()
 
         db = SQLite3(xxx.name, conf)
-        Disqus(db, xml).migrate()
+        Disqus(db, xml, empty_id=False).migrate()
+
+        # TODO: Convert unittest testcases with assertX to plain pytest
+        # asserts, allowing capturing of stdout, like this:
+        #
+        # def test_disqus_empty_id(self, capfd):
+        # [...]
+        # out, err = capfd.readouterr()
+        # assert out == \
+        #     "Isso couldn't import any thread, try again with --empty-id\n"
 
         self.assertEqual(
-            len(db.execute("SELECT id FROM comments").fetchall()), 2)
+            len(db.execute("SELECT id FROM comments").fetchall()), 0)
+
+    def test_disqus_empty_id_workaround(self):
+        """
+        Simulate supplying --empty_id to import call to work around empty
+        thread ids
+        """
+
+        xml = join(dirname(__file__), "disqus.xml")
+        xxx = tempfile.NamedTemporaryFile()
+
+        db = SQLite3(xxx.name, conf)
+        Disqus(db, xml, empty_id=True).migrate()
+
+        self.assertEqual(
+            len(db.execute("SELECT id FROM comments").fetchall()), 3)
 
         self.assertEqual(db.threads["/"]["title"], "Hello, World!")
         self.assertEqual(db.threads["/"]["id"], 1)


### PR DESCRIPTION
Fixes https://github.com/posativ/isso/issues/728

### isso: migrate: Workaround empty Disqus ids/titles

To verify:
```sh
isso -c share/isso-dev.cfg import --empty-id -t disqus isso/tests/disqus.xml
```

### tests: disqus.xml: Add empty id/title testcase

This one will fail by default without `--empty-id`:
```
Isso couldn't import any thread, try again with --empty-id
```

### tests: migration: Split & extend disqus testcases

The addition of a thread with an empty id in `disqus.xml` necessitates adjusting the unit tests to work around this.