### PR TITLE
docs: Expand community & Writing docs pages, import wiki articles

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -43,13 +43,55 @@ Feel free to add your own project to the list!
 
 .. _adjacent-projects:
 
+Tutorials and articles about Isso
+---------------------------------
+
+*These articles also provide concrete examples of using Isso with blog engines
+like Hugo, Ghost or Pelican.*
+
+.. Notes to editors:
+   - Remember to add last updated timestamp (mon/year) to each new/updated article
+   - Only publicly keep most relevant articles/tutorials here, the rest can
+     stay as commented-out ones to avoid duplicates (see list below)
+   - Migration complete from https://github.com/posativ/isso/wiki/Tutorials,
+     wiki page deleted
+
+* `Add comments to a static blog with Isso <https://oktomus.com/posts/2020/add-comments-to-a-static-blog-with-isso/>`_ (1/2020)
+* `Adding Isso Comments to Hugo <https://stiobhart.net/2017-02-24-isso-comments/>`_ (updated 11/2021)
+* `Add comments to a static blog like Hugo or Jekyll with Isso <https://djangocas.dev/blog/hugo/isso-static-blog-comments-setup-and-internal/>`_ (2/2022)
+* `Installing, configuring and integrating Isso into Confluence  <https://confluence.jaytaala.com/display/TKB/Installing%2C+configuring%2C+and+integrating+isso+%28commenting+web+app%29+into+Confluence>`_ (updated 2/2020)
+* `Set up Isso comments on Google Cloud <https://paulness.com/setup-isso-commenting-on-google-compute-engine-vm-cloud/>`_ (4/2018)
+* `Adding Isso comments to a Ghost blog on AWS Lightsail <https://dev.to/sometimescasey/adding-isso-comments-to-a-ghost-blog-on-aws-lightsail-5ea2>`_ (12/2020)
+* `Deploying Isso Commenting System Under Nginx With Docker <https://linuxhandbook.com/deploy-isso-comment/>`_ (2/2022)
+* `Inside The Isso Database <https://snorl.ax/posts/2019/06/10/inside-the-isso-database/>`_ (6/2019)
+
+.. Articles that are not relevant/recent enough:
+   * `Install The Newest Isso and Integrated It with CDN like CloudFlare <https://snorl.ax/posts/2016/07/12/start-to-use-isso/`_
+   * `Bye, Bye Disqus - Say Hello to Isso <https://matthiasadler.info/blog/isso-comment-integration/>`_ (8/2017)
+   * `OverIQ.com: Installing Isso <https://overiq.com/installing-isso/>`_ (7/2020)
+   * `Isso Comments <https://www.hallada.net/2017/11/15/isso-comments.html>`_ (11/2017, updated 5/2019)
+   * `HN Discussion about Isso <https://news.ycombinator.com/item?id=16219570>`_ (1/2018)
+   * `How to add Isso comments to your site <https://therandombits.com/2018/12/how-to-add-isso-comments-to-your-site/>`_ (12/2018)
+   * `Isso: simple self-hosted commenting system <https://blog.phusion.nl/2018/08/16/isso-simple-self-hosted-commenting-system/>`_ (8/2018)
+   * `quintagroup: Isso short project description <https://quintagroup.com/cms/python/isso>`_ (not dated)
+   * `Add comments to your blog with Isso <https://stanislas.blog/2018/02/add-comments-to-your-blog-with-isso/>`_ (2/2018)
+   * `Create a Hugo Blog, along with Isso comment server <https://omicx.cc/posts/2021-04-16-create-a-hugo-blog/>`_ (4/2021)
+   * `Isso comments system on Debian <https://skorotkiewicz.github.io/techlog/isso-comments-system-on-debian/>`_ (10/2018)
+   * `Unborking my ISSO comments system and making it more resilient <https://www.lonecpluspluscoder.com/2021/11/27/fixed-isso-comments-and-made-more-resilient/>`_ (updated 11/2021)
+   * `Setting up Isso for my Hugo static website <https://www.sailadastra.com/posts/isso_comments/>`_ (6/2018)
+   * `Integrate Isso into Hugo <https://www.scisoft.de/posts/technology/190912-isso-hugo/>`_ (9/2019)
+   * `Installing Isso on Uberspace <https://lab.uberspace.de/guide_isso/>`_ (4/2020) (needs to be re-worked!)
+
 Isso-adjacent Projects
 ----------------------
 
-* `wonderfall/isso Docker image <https://github.com/Wonderfall/docker-isso>`_
-* `a grav plugin to integrate isso comments <https://github.com/Sommerregen/grav-plugin-jscomments>`_
-* `a Pelican theme supporting isso comments <https://github.com/Lucas-C/pelican-mg>`_
-* `a Sphinx extension to integrate isso comments <https://github.com/sphinx-notes/isso>`_
+* A plugin for `Grav CMS`_ to integrate isso comments: `grav-plugin-jscomments`_
+* A `Pelican theme supporting isso comments <https://github.com/Lucas-C/pelican-mg>`_
+* A `Sphinx extension to integrate isso comments <https://github.com/sphinx-notes/isso>`_
+* `mihokookayami/isso Docker image <https://hub.docker.com/r/mihokookayami/isso>`_
+
+.. _Grav cms: https://en.wikipedia.org/wiki/Grav_(CMS)
+.. _grav-plugin-jscomments: https://github.com/Sommerregen/grav-plugin-jscomments>
 
 
 .. attention::
@@ -63,8 +105,6 @@ Isso-adjacent Projects
 
    **What's missing?**
 
-   - Import a few suggestions and links from
-     `the wiki on GitHub <https://github.com/posativ/isso/wiki/>`_
    - Define and refine community standards
    - Link to more related projects, investigate moving the "Other options"
      section from the main docs here

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -135,11 +135,17 @@ Syntax standards
 - Use at most three levels of headlines:
   ``===`` for page title, ``---`` for section headings (h3), ``^^^`` for
   sub-headings (h4).
+- Use ``$ /usr/bin/command`` to refer to shell commands and use
+  ``code-block:: bash`` over ``sh``
 - Use ``(.venv) $ python [cmd]`` for things that need to be run inside a
   virtual environment and be consistent
   (see `Sphinx: Narrative Documentation`__)
+- Use ``/path/to/isso/<thing>`` to refer to items inside Isso's main directory
+  and use ``comments.db`` as the name for the database
 - Admonitions should only be: ``note``, ``tip``, ``warning``, ``attention``,
   (maybe also ``error``?). See `docutils: Admonitions`__.
+- Try to keep line length under 80 characters, but don't worry when going over
+  that limit when using links or code blocks
 
 .. __: https://www.sphinx-doc.org/en/master/tutorial/narrative-documentation.html
 .. __: https://docutils.sourceforge.io/docs/ref/rst/directives.html#admonitions

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -15,7 +15,7 @@ example:
 
     One asterisk: *text* for emphasis (italics),
     Two asterisks: **text** for strong emphasis (boldface), and
-    Backquotes: ``text`` for code samples.
+    Double backquotes: ``text`` for code samples.
 
 .. __: https://www.sphinx-doc.org/en/master/
 
@@ -53,8 +53,8 @@ If you have made any changes to the stylesheets, you need to install the
 
 .. code-block:: bash
 
-   apt install sassc
-   make css
+   $ apt install sassc
+   $ make css
 
 .. __: https://github.com/sass/sassc
 
@@ -72,6 +72,34 @@ First and foremost, see the
     This is a paragraph that contains `a link`_ using **references**.
 
     .. _a link: https://domain.invalid/
+
+**Headings:**
+
+Headings must always be *underlined* with at least as many characters as the
+text is wide.
+
+.. code-block:: rst
+
+   Page title
+   ==========
+
+Use page title only once per file (at the top). This is also the name that the
+page will appear under.
+
+.. code-block:: rst
+
+   Section heading (h3)
+   --------------------
+
+Use section heading to divide page into sections
+
+.. code-block:: rst
+
+   Sub-Heading (h4)
+   ^^^^^^^^^^^^^^^^
+
+Use sub-heading only if necessary - if you need this many levels of headings,
+maybe the content chould better be spread out across multiple articles
 
 **Referencing other sections:** (see `:ref:`__)
 
@@ -104,9 +132,9 @@ Use ``.. code-block:: <language>`` and indent the code by one level:
 
    .. code-block:: bash
 
-        sudo apt install python3 python3-pip python3-virtualenv
-        virtualenv .venv
-        source .venv/bin/activate
+        $ sudo apt install python3 python3-pip python3-virtualenv
+        $ virtualenv .venv
+        $ source .venv/bin/activate
         (.venv) $ python [cmd]
 
 Syntax standards

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -1,26 +1,6 @@
 Writing Documentation
 =====================
 
-.. attention::
-
-   This section of the Isso documentation is incomplete. Please help by expanding it.
-
-   Click the ``Edit on GitHub`` button in the top right corner and read the
-   GitHub Issue named
-   `Improve & Expand Documentation <https://github.com/posativ/isso/issues/797>`_
-   for further information.
-
-   **What's missing?**
-
-   - How to install & run Sphinx (note that latest sphinx from pip is needed by theme)
-   - How Sphinx works, what its philosphy is
-   - Small reST intro, also link to the
-     `reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
-   - How to write good documentation, maybe link to a few guides and example sites
-   - More syntax standards, and also correct wrong usage across the docs
-
-   ... and other things about documentation that should be documented.
-
 Introduction
 ------------
 
@@ -175,3 +155,21 @@ Debugging cross-references:
 
 Also make sure you have used ``:ref:`` or ``:doc``
 correctly and not confused the two.
+
+
+.. attention::
+
+   This section of the Isso documentation is incomplete. Please help by expanding it.
+
+   Click the ``Edit on GitHub`` button in the top right corner and read the
+   GitHub Issue named
+   `Improve & Expand Documentation <https://github.com/posativ/isso/issues/797>`_
+   for further information.
+
+   **What's missing?**
+
+   - How Sphinx works, what its philosphy is
+   - How to write good documentation, maybe link to a few guides and example sites
+   - More syntax standards, and also correct wrong usage across the docs
+
+   ... and other things about documentation that should be documented.

--- a/docs/docs/guides/tips-and-tricks.rst
+++ b/docs/docs/guides/tips-and-tricks.rst
@@ -118,6 +118,54 @@ Next you can import you json dump:
     ~> isso -c /path/to/isso.cfg import -t generic comment-dump.json
     [100%]  53 threads, 192 comments
 
+
+Pretty-print entire comments database
+-------------------------------------
+
+.. Migration complete from https://github.com/posativ/isso/wiki/Tips-&-tricks
+
+The following bash function pretty-print the entire comments DB sorted by
+insertion date.
+
+.. code-block:: bash
+
+   get_blog_comments () {
+       ssh $host sqlite3 -line /path/to/isso/isso.db \
+           "'SELECT t.uri,c.created,c.modified,c.text,c.author,c.email,c.website \
+             FROM comments AS c, threads as t WHERE c.tid = t.id;'" \
+           | perl -wpe '/(created|modified) = ./&&s/= (.*)/"= ".scalar(localtime($1))/e';
+   }
+
+Example output:
+
+.. code-block:: text
+
+        uri = /lucas/blog/2014/12/12/fr-la-tete-dans-le-guidon/
+    created = Mon Dec 15 13:10:28 2014
+   modified =
+       text = Merci ! Je suis très content d'apprendre que cette lecture a pu plaire à quelqu'un
+   N'hésitez pas à partager vos propres réflexions et astuces dans les commentaires.
+     author = lucas
+      email = lucas@chezsoi.org
+    website = https://chezsoi.org/lucas/blog
+
+
+Delete IP addresses weekly
+--------------------------
+
+Add this to your ``crontab`` to set all saved commenter IP addresses to
+``127.0.0.1`` to preserve their privacy under GDPR:
+
+.. code-block:: text
+
+   @weekly /usr/bin/sqlite3 /path/to/isso/comments.db 'UPDATE comments SET remote_addr = "127.0.0.1";'
+
+From `blog.mdosch.de <https://blog.mdosch.de/2018/05/20/isso-ip-adressen-woechentlich-loeschen/>`_:
+
+*Note that Isso already anonymizes the last part of IP addresses by setting
+them to to zero.*
+
+
 .. attention::
 
    This section of the Isso documentation is incomplete. Please help by expanding it.

--- a/docs/docs/guides/troubleshooting.rst
+++ b/docs/docs/guides/troubleshooting.rst
@@ -7,6 +7,9 @@ Some uberspace users experienced problems with isso and they solved their
 issues by adding `DirectoryIndex disabled` as the first line in the `.htaccess`
 file for the domain the isso server is running on.
 
+The `Installing Isso on Uberspace <https://lab.uberspace.de/guide_isso/>`_
+guide should also be helpful.
+
 pkg_ressources.DistributionNotFound
 -----------------------------------
 


### PR DESCRIPTION
### docs: tips-n-tricks: Import from wiki, add weekly scrub

Wiki pages formerly under https://github.com/posativ/isso/wiki consolidated into docs

### docs: community: Add more articles, edit projects

### docs: troubleshooting: Add link to uberspace lab`

### docs/contrib: doc:
- More syntax suggestions
- Move admon down; rm done items
- Add headings section, shellcode