### PR TITLE
docs: Document snapshots, add "New in version x", def.-list styling, better config options documentation

### DIFF
--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -238,8 +238,8 @@ main {
     main .sidebar ul {
       margin-top: 0.5em;
       margin-bottom: 1em; }
-    main .sidebar ul:last-child {
-      margin-bottom: 0; }
+      main .sidebar ul:last-child {
+        margin-bottom: 0; }
     main .sidebar li {
       border-left: solid 2px #d3d3d3;
       margin-left: 0.25em;
@@ -320,6 +320,15 @@ main {
           margin: 0; }
     main .docs table.hlist * {
       vertical-align: top; }
+    main .docs .versionadded,
+    main .docs .versionchanged,
+    main .docs .deprecated {
+      margin: 0.3em 0; }
+      main .docs .versionadded span,
+      main .docs .versionchanged span,
+      main .docs .deprecated span {
+        background: lightyellow;
+        font-style: italic; }
   main .vcs-edit {
     font-size: 1.16em;
     line-height: 1.16em;
@@ -333,14 +342,22 @@ main {
     text-decoration: none;
     color: #2980b9; }
   main dt {
+    font-family: Monaco, Menlo, Consolas, monospace;
     font-weight: bold;
-    margin: 1.4em 0 0.4em;
     font-size: 16px;
-    line-height: 1.4em; }
-  main dt code {
-    font-size: 16px; }
+    line-height: 1.4em;
+    display: inline-block;
+    margin: 1.4em 0 0.4em;
+    padding: 3px 6px;
+    background: #e7f2fa;
+    color: #2f2f2f;
+    border-top: 2px solid #a4cfeb; }
   main dd {
     margin-left: 1.2em; }
+    main dd dl.simple dt {
+      border-top: none;
+      background: inherit;
+      color: inherit; }
   main dl {
     margin-bottom: 0.4em; }
 
@@ -386,7 +403,7 @@ main {
       float: left;
       width: 1.4rem;
       height: 1.4rem;
-      font-family: monospace;
+      font-family: Monaco, Menlo, Consolas, monospace;
       font-size: 1.3rem;
       border-radius: 999px;
       text-align: center;

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -28,7 +28,7 @@ body {
 .push, .footer {
   height: 2em; }
   .push a, .push a:visited, .footer a, .footer a:visited {
-    color: #00aac2;
+    color: #2980b9;
     text-decoration: none; }
 
 .header {
@@ -231,7 +231,7 @@ main {
     main .sidebar:last-child {
       margin-right: 0; }
     main .sidebar strong {
-      color: #00aac2;
+      color: #2980b9;
       font-weight: bold;
       text-transform: uppercase;
       letter-spacing: 0.5px; }
@@ -251,15 +251,15 @@ main {
       main .sidebar li a {
         color: #2f2f2f; }
     main .sidebar .current {
-      border-left-color: #00aac2; }
+      border-left-color: #2980b9; }
       main .sidebar .current a.current {
-        color: #00aac2;
+        color: #2980b9;
         font-weight: bold; }
     main .sidebar #searchbox {
       color: #2f2f2f;
       margin: 0 0 1.4em; }
       main .sidebar #searchbox h2 {
-        color: #00aac2;
+        color: #2980b9;
         font-weight: bold;
         text-transform: uppercase;
         font-size: 14px; }
@@ -331,7 +331,7 @@ main {
       vertical-align: top; }
   main a {
     text-decoration: none;
-    color: #00aac2; }
+    color: #2980b9; }
   main dt {
     font-weight: bold;
     margin: 1.4em 0 0.4em;

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -318,6 +318,8 @@ main {
         margin-right: 2em; }
         main .docs ul li > ul {
           margin: 0; }
+    main .docs table.hlist * {
+      vertical-align: top; }
   main .vcs-edit {
     font-size: 1.16em;
     line-height: 1.16em;

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -390,6 +390,11 @@ main {
         }
       }
     }
+
+    // For `.. hlist::` directive, do not vertically center columns:
+    table.hlist * {
+        vertical-align: top;
+    }
   }
 
   // "Edit on Github" link

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -6,10 +6,14 @@ $max-width: em(1280); // Max-width of the outer container, divided by 16
 
 $blue: #2980b9;
 $strong-blue: #6ab0de;
+$background-blue: #e7f2fa;
 $text: #2f2f2f;
 $muted-grey: #151515;
 $admon-todo: #f0b37e;
 $highlighted: #f1c40f;
+$versionchanged: lightyellow;
+
+$monospace: Monaco, Menlo, Consolas, monospace;
 
 * {
   margin: 0;
@@ -260,10 +264,10 @@ main {
     ul {
       margin-top: 0.5em;
       margin-bottom: 1em;
-    }
 
-    ul:last-child {
-      margin-bottom: 0;
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     li {
@@ -336,7 +340,7 @@ main {
 
     pre, code {
       font-size: 14px;
-      font-family: Monaco, Menlo, Consolas, monospace;
+      font-family: $monospace;
     }
 
     code {
@@ -396,6 +400,18 @@ main {
     table.hlist * {
         vertical-align: top;
     }
+
+    .versionadded,
+    .versionchanged,
+    .deprecated {
+
+        margin: 0.3em 0;
+
+        span {
+            background: $versionchanged;
+            font-style: italic;
+        }
+    }
   }
 
   // "Edit on Github" link
@@ -417,18 +433,29 @@ main {
   }
 
   dt {
+    font-family: $monospace;
     font-weight: bold;
-    margin: 1.4em 0 0.4em;
     font-size: 16px;
     line-height: 1.4em;
-  }
-  dt code {
-    font-size: 16px;
+    display: inline-block;
+    margin: 1.4em 0 0.4em;
+    padding: 3px 6px;
+
+    background: $background-blue;
+    color: $text;
+
+    border-top: 2px solid lighten($strong-blue, 14);
   }
   dd {
     margin-left: 1.2em;
-  }
 
+    // Nested definitions should not have blue styling
+    & dl.simple dt {
+      border-top: none;
+      background: inherit;
+      color: inherit;
+    }
+  }
   dl {
     margin-bottom: 0.4em;
   }
@@ -499,7 +526,7 @@ main {
       float: left;
       width: 1.4rem;
       height: 1.4rem;
-      font-family: monospace;
+      font-family: $monospace;
       font-size: 1.3rem;
       border-radius: 999px;
       text-align: center;

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -4,7 +4,8 @@
 // Override bourbon _grid.scss
 $max-width: em(1280); // Max-width of the outer container, divided by 16
 
-$blue: #00aac2;
+$blue: #2980b9;
+$strong-blue: #6ab0de;
 $text: #2f2f2f;
 $muted-grey: #151515;
 $admon-todo: #f0b37e;

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -178,6 +178,8 @@ Helpful links:
 
 - `Cross-referencing with Sphinx <https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html>`_
 - `Sphinx directives <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html>`_
+- For theme authors: Look at
+  `sphinx-rtd-theme internals <https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html>`_
 
 Debugging cross-references:
 

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -154,6 +154,9 @@ Syntax standards
   (maybe also ``error``?). See `docutils: Admonitions`__.
 - Try to keep line length under 80 characters, but don't worry when going over
   that limit when using links or code blocks
+- Use ``.. versionadded::``, ``.. versionchanged::`` and ``.. deprecated::`` to
+  make it clear to readers which version of Isso are affected by an
+  option or behavior
 
 .. __: https://www.sphinx-doc.org/en/master/tutorial/narrative-documentation.html
 .. __: https://docutils.sourceforge.io/docs/ref/rst/directives.html#admonitions
@@ -174,6 +177,7 @@ Help
 Helpful links:
 
 - `Cross-referencing with Sphinx <https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html>`_
+- `Sphinx directives <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html>`_
 
 Debugging cross-references:
 

--- a/docs/docs/contributing/index.rst
+++ b/docs/docs/contributing/index.rst
@@ -142,7 +142,9 @@ What is currently needed?
 - Look at `open issues with label "good-first-issue"`__
 - Look at `open issues with label "needs-decision"`__ and chime in with your
   well thought-out opinion
-- Look at `milestones`__
+- Look at `milestones`__ - the next release of Isso will be version 0.13, and
+  you can help by looking for open issues and PRs that
+  `contribute to 0.13 <https://github.com/posativ/isso/milestone/5>`_
 - Nicer automated testing, via docker or GH actions, of most of the available
   setup options (fastcgi/proxy configs, docker, apachge/nginx, ...)
 
@@ -184,7 +186,8 @@ It is built using many different technologies and moving parts
 
 Below is a non-exhaustive list of tools, services, dependencies and
 technologies Isso's contributors and maintainers need to at least peripherally
-be aware of - that's a lot to demand of someone!
+be aware of - that's a lot to demand of someone! Your aim should be to reduce
+this complexity, not add to it.
 
 .. hlist::
    :columns: 2

--- a/docs/docs/contributing/index.rst
+++ b/docs/docs/contributing/index.rst
@@ -186,51 +186,62 @@ Below is a non-exhaustive list of tools, services, dependencies and
 technologies Isso's contributors and maintainers need to at least peripherally
 be aware of - that's a lot to demand of someone!
 
-Docs
-    - apiDoc
-    - sphinx with reST syntax
+.. hlist::
+   :columns: 2
 
-Python
-    - Pallets project: werkzeug, jinja2, flask
-    - misaka (and changing config opts)
-    - bleach, html5lib
-    - different python versions, OS versions
-    - flake8
-    - setuptools, pip
-    - python package index (pypa) uploading
+   * **Docs**
 
-Python testing
-    - pytest (unit testing)
-    - coverage
+     -  apiDoc
+     -  sphinx with reST syntax
 
-Convenience tools
-    - docker
-    - vagrant
-    - ansible
+   * **Python**
 
-Javascript
-    - nodejs
-    - npm
-    - package.json oddities
-    - webpack
-    - Jest
-    - puppeteer
-    - Browser compatibility and ES5/ES6 standards
+     -  Pallets project: werkzeug, jinja2, flask
+     -  misaka (and changing config opts)
+     -  bleach, html5lib
+     -  Different python versions, OS versions
+     -  setuptools, pip
+     -  Python Package Index (PyPI) uploading
 
-Development tools
-    - make
-    - Github Actions
+   * **Python testing**
 
-Deployment options
-    - ``isso run [opts]``
-    - Apache (``mod_wsgi``)
-    - Apache (``mod_fastcgi``)
-    - Apache (proxy)
-    - nginx (proxy)
-    - uwswgi
-    - gunicorn
-    - gevent
+     -  pytest (unit testing)
+     -  coverage
+     -  flake8
 
-Importers
-    - Current disqus export format
-    - Current and past Wordpress export formats
+   * **Convenience tools**
+
+     -  Docker
+     -  Vagrant
+     -  Ansible
+
+   * **Javascript**
+
+     -  Node.js
+     -  npm
+     -  package.json oddities
+     -  webpack
+     -  Jest
+     -  puppeteer
+     -  Browser compatibility and ES5/ES6 standards
+
+   * **Development tools**
+
+     -  make
+     -  Github Actions
+
+   * **Deployment options**
+
+     -  ``isso run [opts]``
+     -  Apache (``mod_wsgi``)
+     -  Apache (``mod_fastcgi``)
+     -  Apache (proxy)
+     -  nginx (proxy)
+     -  uwswgi
+     -  gunicorn
+     -  gevent
+
+   * **Importers**
+
+     -  Current disqus export format
+     -  Current and past Wordpress export formats

--- a/docs/docs/reference/client-config.rst
+++ b/docs/docs/reference/client-config.rst
@@ -46,7 +46,7 @@ english translation of the ``postbox-notification`` message, you could add:
 data-isso-* directives
 ------------------------
 
-``data-isso``
+data-isso
    Isso usually detects the REST API automatically, but when you serve the JS
    script on a different location, this may fail. Use `data-isso` to
    override the API location:
@@ -55,7 +55,7 @@ data-isso-* directives
 
        <script data-isso="/isso" src="/path/to/embed.min.js"></script>
 
-``data-isso-css-url``
+data-isso-css-url
     Set URL from which to fetch ``isso.css``, e.g. from a CDN.
     Defaults to fetching from the API endpoint.
 
@@ -63,7 +63,7 @@ data-isso-* directives
 
         <script src="..." data-isso-css-url="/path/to/isso.css"></script>
 
-``data-isso-css``
+data-isso-css
     Set to `false` prevents Isso from automatically appending the stylesheet.
     Defaults to `true`.
 
@@ -71,7 +71,7 @@ data-isso-* directives
 
         <script src="..." data-isso-css="false"></script>
 
-``data-isso-lang``
+data-isso-lang
     Always render the Isso UI in this language, ignoring what the
     user-agent says is the preferred language.  The default is to
     honor the user-agent's preferred language, and this can be
@@ -88,7 +88,7 @@ data-isso-* directives
     <https://github.com/posativ/isso/tree/master/isso/js/app/i18n>`_ of
     the source tree.
 
-``data-isso-default-lang``
+data-isso-default-lang
     Render the Isso UI in this language when the user-agent does not
     specify a preferred language, or if the language it specifies is not
     supported.  Like ``data-isso-lang``, the value of this property should
@@ -97,33 +97,35 @@ data-isso-* directives
     If you specify both ``data-isso-default-lang`` and ``data-isso-lang``,
     ``data-isso-lang`` takes precedence.
 
-``data-isso-max-comments-top`` and ``data-isso-max-comments-nested``
+    .. versionadded:: 0.12.6
+
+data-isso-max-comments-top, data-isso-max-comments-nested
     Number of top level (or nested) comments to show by default. If some
     comments are not shown, an "X Hidden" link is shown.
 
-    Set to `"inf"` to show all, or `"0"` to hide all.
+    Set to ``"inf"`` to show all, or ``"0"`` to hide all.
 
-``data-isso-reveal-on-click``
+data-isso-reveal-on-click
     Number of comments to reveal on clicking the "X Hidden" link.
 
-``data-isso-avatar``
+data-isso-avatar
     Enable or disable avatar generation. Ignored if gravatar is enabled on
     server side, since gravatars will take precedence and disable avatar
     generation.
 
-``data-isso-avatar-bg``
+data-isso-avatar-bg
     Set avatar background color. Any valid CSS color will do.
 
-``data-isso-avatar-fg``
+data-isso-avatar-fg
     Set avatar foreground color. Up to 8 colors are possible. The default color
     scheme is based in `this color palette <http://colrd.com/palette/19308/>`_.
     Multiple colors must be separated by space. If you use less than eight colors
     and not a multiple of 2, the color distribution is not even.
 
-``data-isso-vote``
+data-isso-vote
     Enable or disable voting feature on the client side.
 
-``data-isso-vote-levels``
+data-isso-vote-levels
     List of vote levels used to customize comment appearance based on score.
     Provide a comma-separated values (eg. `"0,5,10,25,100"`) or a JSON array (eg. `"[-5,5,15]"`).
 
@@ -135,7 +137,7 @@ data-isso-* directives
 
     These classes can then be used to customize the appearance of comments (eg. put a star on popular comments)
 
-``data-isso-feed``
+data-isso-feed
     Enable or disable the addition of a link to the feed for the comment
     thread. The link will only be valid if the appropriate setting, in
     ``[rss]`` section, is also enabled server-side.
@@ -148,18 +150,28 @@ In earlier versions the following settings had to mirror the
 corresponding settings in the server configuration, but they are now
 read out from the server automatically.
 
-``data-isso-reply-to-self``
+data-isso-reply-to-self
+    .. deprecated:: 0.12.6
+
     Set to `true` when spam guard is configured with `reply-to-self = true`.
 
-``data-isso-require-author``
+data-isso-require-author
+    .. deprecated:: 0.12.6
+
     Set to `true` when spam guard is configured with `require-author = true`.
 
-``data-isso-require-email``
+data-isso-require-email
+    .. deprecated:: 0.12.6
+
     Set to `true` when spam guard is configured with `require-email = true`.
 
-``data-isso-reply-notifications``
+data-isso-reply-notifications
+    .. deprecated:: 0.12.6
+
     Set to `true` when reply notifications is configured with `reply-notifications = true`.
 
-``data-isso-gravatar``
+data-isso-gravatar
+    .. deprecated:: 0.12.6
+
     Set to `true` when gravatars are enabled with `gravatar = true` in the
     server configuration.

--- a/docs/docs/reference/server-config.rst
+++ b/docs/docs/reference/server-config.rst
@@ -35,25 +35,34 @@ General
 .. _configure-general:
 
 In this section, you configure most comment-related options such as database path,
-session key and hostname. Here are the default values for this section:
+session key and hostname.
+
+Here are the **default values** for this section:
 
 .. code-block:: ini
 
     [general]
-    dbpath = /tmp/isso.db
+    dbpath = /tmp/comments.db
     name =
     host =
     max-age = 15m
     notify = stdout
     log-file =
+    gravatar = false
+    gravatar-url = https://www.gravatar.com/avatar/{}?d=identicon&s=55
+    latest-enabled = false
 
 dbpath
-    file location to the SQLite3 database, highly recommended to change this
+    File location to the SQLite3 database, highly recommended to change this
     location to a non-temporary location!
 
+    Default: ``/tmp/comments.db``
+
 name
-    required to dispatch :ref:`multiple websites <configure-multiple-sites>`,
+    Required to dispatch :ref:`multiple websites <configure-multiple-sites>`,
     not used otherwise.
+
+    Default: (empty)
 
 host
     Your website(s). If Isso is unable to connect to at least one site, you'll
@@ -73,9 +82,13 @@ host
             http://example.tld/
             https://example.tld/
 
+    Default: (empty)
+
 max-age
-    time range that allows users to edit/remove their own comments. See
+    Time range that allows users to edit/remove their own comments. See
     :ref:`Appendum: Timedelta <appendum-timedelta>` for valid values.
+
+    Default: ``15m``
 
 notify
     Select notification backend(s) for new comments, separated by comma.
@@ -89,14 +102,20 @@ notify
         Send notifications via SMTP on new comments with activation (if
         moderated) and deletion links.
 
+    Default: ``stdout``
+
 reply-notifications
     Allow users to request E-mail notifications for replies to their post.
 
     It is highly recommended to also turn on moderation when enabling this
     setting, as Isso can otherwise be easily exploited for sending spam.
 
+    Default: ``false``
+
 log-file
     Log console messages to file instead of standard out.
+
+    Default: (empty)
 
 gravatar
     When set to ``true`` this will add the property "gravatar_image"
@@ -105,14 +124,17 @@ gravatar
     This is only true when using the default value for "gravatar-url"
     which contains the query string param ``d=identicon`` ...
 
+    Default: ``false``
+
 gravatar-url
-    Url for gravatar images. The "{}" is where the email hash will be placed.
-    Defaults to "https://www.gravatar.com/avatar/{}?d=identicon&s=55"
+    Url for gravatar images. The ``{}`` is where the email hash will be placed.
+
+    Default: ``https://www.gravatar.com/avatar/{}?d=identicon&s=55``
 
 latest-enabled
-    If True it will enable the ``/latest`` endpoint. Optional, defaults
-    to False.
+    If true it will enable the ``/latest`` endpoint.
 
+    Default: ``false``
 
 
 .. _CORS: https://developer.mozilla.org/en/docs/HTTP/Access_control_CORS
@@ -133,19 +155,25 @@ Enable moderation queue and handling of comments still in moderation queue
     purge-after = 30d
 
 enabled
-    enable comment moderation queue. This option only affects new comments.
+    Enable comment moderation queue. This option only affects new comments.
     Comments in moderation queue are not visible to other users until you
     activate them.
 
+    Default: ``false``
+
 approve-if-email-previously-approved
-    automatically approve comments by an email address if that address has
+    Automatically approve comments by an email address if that address has
     had a comment approved within the last 6 months. No ownership verification
     is done on the entered email address. This means that if someone is able
     to guess correctly the email address used by a previously approved author,
     they will be able to have their new comment auto-approved.
 
+    Default: ``false``
+
 purge-after
-    remove unprocessed comments in moderation queue after given time.
+    Remove unprocessed comments in moderation queue after given time.
+
+    Default: ``30d``
 
 
 .. _configure-server-block:
@@ -159,11 +187,14 @@ HTTP server configuration.
 
     [server]
     listen = http://localhost:8080
+    public-endpoint =
     reload = off
     profile = off
+    trusted-proxies =
+    samesite =
 
 listen
-    interface to listen on. Isso supports TCP/IP and unix domain sockets:
+    Interface to listen on. Isso supports TCP/IP and unix domain sockets:
 
     .. code-block:: ini
 
@@ -179,29 +210,39 @@ listen
 
     Does not apply for `uWSGI`.
 
+    Default: ``http://localhost:8080``
+
 public-endpoint
-    public URL that Isso is accessed from by end users. Should always be
+    Public URL that Isso is accessed from by end users. Should always be
     a http:// or https:// absolute address. If left blank, automatic
     detection is attempted. Normally only needs to be specified if
-    different than the `listen` setting.
+    different than the ``listen`` setting.
+
+    Default: (empty)
 
 reload
-    reload application, when the source code has changed. Useful for
+    Reload application, when the source code has changed. Useful for
     development. Only works with the internal webserver.
 
+    Default: ``off``
+
 profile
-    show 10 most time consuming function in Isso after each request. Do
+    Show 10 most time consuming function in Isso after each request. Do
     not use in production.
 
+    Default: ``off``
+
 trusted-proxies
-    an optional list of reverse proxies IPs behind which you have deployed
+    An optional list of reverse proxies IPs behind which you have deployed
     your Isso web service (e.g. `127.0.0.1`).
     This allow for proper remote address resolution based on a
     `X-Forwarded-For` HTTP header, which is important for the mechanism
     forbiding several comment votes coming from the same subnet.
 
+    Default: (empty)
+
 samesite
-    override ``Set-Cookie`` header ``SameSite`` value.
+    Override ``Set-Cookie`` header ``SameSite`` value.
     Needed for setups where isso is not hosted on the same domain, e.g. called
     from example.org and hosted under comments.example.org.
     By default, isso will set ``SameSite=None`` when served over https and
@@ -210,6 +251,8 @@ samesite
     and `#682 <https://github.com/posativ/isso/issues/682>`_ for details).
 
     Accepted values: ``None``, ``Lax``, ``Strict``
+
+    Default: (empty)
 
 .. _configure-smtp:
 
@@ -233,34 +276,54 @@ also can moderate (=activate or delete) comments. Don't forget to configure
     timeout = 10
 
 username
-    self-explanatory, optional
+    Self-explanatory, *optional*
+
+    Default: (empty)
 
 password
     self-explanatory (yes, plain text, create a dedicated account for
-    notifications), optional.
+    notifications), *optional*.
+
+    Default: (empty)
 
 host
     SMTP server
 
+    Default: ``localhost``
+
 port
     SMTP port
 
+    Default: ``587``
+
 security
-    use a secure connection to the server, possible values: *none*, *starttls*
-    or *ssl*. Note, that there is no easy way for Python 2.7 and 3.3 to
-    implement certification validation and thus the connection is vulnerable to
-    Man-in-the-Middle attacks. You should definitely use a dedicated SMTP
-    account for Isso in that case.
+    Use a secure connection to the server.
+
+    Accepted values: ``none``, ``starttls``, ``ssl```
+
+    Default: ``starttls``
+
+    .. todo: Following is outdated.
+       Note that there is no easy way for Python 2.7 and 3.3 to implement
+       certification validation and thus the connection is vulnerable to
+       Man-in-the-Middle attacks. You should definitely use a dedicated SMTP
+       account for Isso in that case.
 
 to
-    recipient address, e.g. your email address
+    Recipient address, e.g. your email address
+
+    Default: (empty)
 
 from
-    sender address, e.g. `"Foo Bar" <isso@example.tld>`
+    Sender address, e.g. ``"Foo Bar" <isso@example.tld>``
+
+    Default: (empty)
 
 timeout
-    specify a timeout in seconds for blocking operations like the
+    Specify a timeout in seconds for blocking operations like the
     connection attempt.
+
+    Default: ``10``
 
 
 Guard
@@ -280,28 +343,40 @@ for IPv4, ``/48`` for IPv6).
     require-email = false
 
 enabled
-    enable guard, recommended in production. Not useful for debugging
+    Enable guard, recommended in production. Not useful for debugging
     purposes.
 
+    Default: ``true``
+
 ratelimit
-    limit to N new comments per minute.
+    Limit to N new comments per minute.
+
+    Default: ``2``
 
 direct-reply
-    how many comments directly to the thread (prevent a simple
+    How many comments directly to the thread (prevent a simple
     `while true; do curl ...; done`.
 
+    Default: ``3``
+
 reply-to-self
-    allow commenters to reply to their own comments when they could still edit
+    Allow commenters to reply to their own comments when they could still edit
     the comment. After the editing timeframe is gone, commenters can reply to
     their own comments anyways.
 
+    Default: ``false``
+
 require-author
-    force commenters to enter a value into the author field. No validation is
+    Force commenters to enter a value into the author field. No validation is
     performed on the provided value.
 
+    Default: ``false``
+
 require-email
-    force commenters to enter a value into the email field. No validation is
+    Force commenters to enter a value into the email field. No validation is
     performed on the provided value.
+
+    Default: ``false``
 
 .. _configure-markup:
 
@@ -321,30 +396,58 @@ supported, but new languages are relatively easy to add.
 
 options
     `Misaka-specific Markdown extensions <https://misaka.61924.nl/#api>`_, all
-    extension flags can be used there, separated by comma, either by their name
-    or as ``EXT_``.
+    extension options can be used there, separated by comma, either by their
+    name (``fenced-code``) or as ``EXT_FENCED_CODE``.
 
-    **Careful:** Misaka 1.0 used ``snake_case``, but 2.0 needs ``dashed-case``!
+    The `flask-misaka docs <https://flask-misaka.readthedocs.io/en/latest/#options>`_
+    have a good explanation of what each extension options does.
+
+    Note: Use e.g. ``fenced-code`` (with a ``-`` dash) instead of
+    ``fenced_code`` (underline) to refer to extension names.
+
+    Default: ``strikethrough, superscript, autolink, fenced-code``
 
 flags
     `Misaka-specific HTML rendering flags
     <https://misaka.61924.nl/#html-render-flags>`_, all html rendering flags
-    can be used here, separated by comma, either by their name or as ``HTML_``.
-    Per Misaka's defaults, no flags are set.
+    can be used here, separated by comma, either by their name (``hard-wrap``)
+    or as e.g. ``HTML_HARD_WRAP``.
+
+    Default: (empty)
+
+    .. versionadded:: 0.12.4
 
 allowed-elements
-    Additional HTML tags to allow in the generated output, comma-separated. By
-    default, only *a*, *blockquote*, *br*, *code*, *del*, *em*, *h1*, *h2*,
-    *h3*, *h4*, *h5*, *h6*, *hr*, *ins*, *li*, *ol*, *p*, *pre*, *strong*,
-    *table*, *tbody*, *td*, *th*, *thead* and *ul* are allowed.
+    **Additional** HTML tags to allow in the generated output, comma-separated.
+
+    By default, only ``a``, ``blockquote``, ``br``, ``code``, ``del``, ``em``,
+    ``h1``, ``h2``, ``h3``, ``h4``, ``h5``, ``h6``, ``hr``, ``ins``, ``li``,
+    ``ol``, ``p``, ``pre``, ``strong``, ``table``, ``tbody``, ``td``, ``th``,
+    ``thead`` and ``ul`` are allowed.
+
+    .. warning::
+
+       This option (together with ``allowed-attributes``) is frequently
+       misunderstood. Setting e.g. this list to only ``a, blockquote`` will
+       mean that ``br, code, del, ...`` and all other default allowed tags are
+       still allowed. You can only add *additional* elements here.
+
+       It is planned to change this behavior, see
+       `this issue <https://github.com/posativ/isso/issues/751>`_.
+
+    Default: (empty)
 
 allowed-attributes
-    Additional HTML attributes (independent from elements) to allow in the
-    generated output, comma-separated. By default, only *align* and *href* are
-    allowed.
+    **Additional** HTML attributes (independent from elements) to allow in the
+    generated output, comma-separated.
 
-To allow images in comments, you just need to add ``allowed-elements = img`` and
-``allowed-attributes = src``.
+    By default, only ``align`` and ``href`` are allowed (same caveats as for
+    ``allowed-elements`` above apply)
+
+    Default: (empty)
+
+.. note:: To allow images in comments, you need to add
+   ``allowed-elements = img`` and *also* ``allowed-attributes = src``.
 
 Hash
 ----
@@ -363,15 +466,19 @@ salt
     pepper (yet). The default value has been in use since the release of Isso
     and generates the same identicons for same addresses across installations.
 
+    Default: ``Eech7co8Ohloopo9Ol6baimi``
+
 algorithm
-    Hash algorithm to use -- either from Python's `hashlib` or PBKDF2 (a
+    Hash algorithm to use -- either from Python's ``hashlib`` or PBKDF2 (a
     computational expensive hash function).
 
-    The actual identifier for PBKDF2 is `pbkdf2:1000:6:sha1`, which means 1000
-    iterations, 6 bytes to generate and SHA1 as pseudo-random family used for
-    key strengthening.
-    Arguments have to be in that order, but can be reduced to `pbkdf2:4096`
+    The actual identifier for PBKDF2 is ``pbkdf2:1000:6:sha1``, which means
+    1000 iterations, 6 bytes to generate and SHA1 as pseudo-random family used
+    for key strengthening.
+    Arguments have to be in that order, but can be reduced to ``pbkdf2:4096``
     for example to override the iterations only.
+
+    Default: ``pbkdf2``
 
 .. _configure-rss:
 
@@ -389,10 +496,14 @@ are enabled as soon as there is a base URL defined in this section.
     limit = 100
 
 base
-    base URL to use to build complete URI to pages (by appending the URI from Isso)
+    Base URL to use to build complete URI to pages (by appending the URI from Isso)
+
+    Default: (empty)
 
 limit
     number of most recent comments to return for a thread
+
+    Default: ``100``
 
 Admin
 -----
@@ -406,13 +517,17 @@ comments. The interface is available under ``/admin`` on your isso URL.
 
    [admin]
    enabled = true
-   password = secret
+   password = please_choose_a_strong_password
 
 enabled
-   whether to enable the admin interface
+   Whether to enable the admin interface
+
+   Default: ``false``
 
 password
-   the plain text password to use for logging into the administration interface
+   The plain text password to use for logging into the administration interface
+
+   Default: ``please_choose_a_strong_password``
 
 Appendum
 --------

--- a/docs/docs/technical-docs/testing-client.rst
+++ b/docs/docs/technical-docs/testing-client.rst
@@ -51,6 +51,9 @@ You should receive output that looks similar to the following:
    Time:        0.907 s, estimated 1 s
    Ran all test suites matching /isso\/js\/tests\/unit\//i.
 
+If you receive an error saying ``1 snapshot failed`` see
+:ref:`Updating snapshots <updating-snapshots>`
+
 
 End-to-End Integration tests
 ----------------------------
@@ -147,6 +150,58 @@ who happens to know very little about testing (or even Javascript in general).
 Feel free to suggest improvements and change this!
 
 .. __: https://mailchimp.com/developer/open-commerce/docs/testing-requirements/>
+
+.. _updating-snapshots:
+
+Updating snapshots
+^^^^^^^^^^^^^^^^^^
+
+The ``Jest`` tests make use of `snapshots <https://jestjs.io/docs/snapshot-testing>`_. Say you want to ensure that the Postbox ``<textarea>`` always looks like this:
+
+.. code-block:: html
+
+   <div class="isso-textarea-wrapper">
+     <div class="isso-textarea isso-placeholder">
+         Type Comment Here (at least 3 chars)</div>
+     <div class="isso-preview">[...]</div>
+   </div>
+
+You *could* write this as:
+
+.. code-block:: javascript
+
+   let expected_html = '<div class="isso-textarea-wrapper> [...]';
+   expect($(".isso-textarea-wrapper").innerHTML.toBe(expected_html);
+
+But then your resulting test files would quickly grow quite messy, especially
+for large components where the ``expected_html`` block would span whole pages.
+That is why ``Jest`` offers to check in those expected blocks as ``snapshots``,
+which will saved into e.g. ``isso/js/tests/unit/__snapshots__/*.snap``
+
+.. code-block:: javascript
+
+   expect($(".isso-textarea-wrapper").innerHTML).toMatchSnapshot();
+
+If you have created a commit which changes the HTML that is generated on the
+client side (and you're sure it is correct) or written a new test case that
+uses snapshots, check in or update the snapshot file by running
+``npm run test-unit -- -u``. You should see something like the following:
+
+.. code-block:: text
+
+   npx jest --config isso/js/jest-unit.config.js isso/js/tests/unit/ -u``
+   PASS  isso/js/tests/unit/isso.test.js
+   › 1 snapshot updated.
+
+Make a new commit for the changes to the snapshot - here's an example:
+
+.. code-block:: text
+
+   isso: tests/unit: Update isso.js snapshot
+
+   Prepending `isso-` to the element classes causes a change in
+   the generated HTML and necessitates an update of the
+   snapshot.
 
 .. attention::
 

--- a/docs/docs/toc.rst
+++ b/docs/docs/toc.rst
@@ -5,39 +5,39 @@
    :maxdepth: 1
    :caption: Guides
 
-   Quickstart <guides/quickstart.rst>
-   Tips & Tricks <guides/tips-and-tricks.rst>
-   Troubleshooting <guides/troubleshooting.rst>
-   Advanced Integration <guides/advanced-integration.rst>
-   FAQ <guides/faq.rst>
+   Quickstart <guides/quickstart>
+   Tips & Tricks <guides/tips-and-tricks>
+   Troubleshooting <guides/troubleshooting>
+   Advanced Integration <guides/advanced-integration>
+   FAQ <guides/faq>
 
 .. toctree::
    :hidden:
    :maxdepth: 0
    :caption: Reference
 
-   Installation <reference/installation.rst>
-   Server Configuration <reference/server-config.rst>
-   Client Configuration <reference/client-config.rst>
-   Deployment <reference/deployment.rst>
-   Multiple Sites & Sub-URI <reference/multi-site-sub-uri.rst>
-   Server API <reference/server-api.rst>
+   Installation <reference/installation>
+   Server Configuration <reference/server-config>
+   Client Configuration <reference/client-config>
+   Deployment <reference/deployment>
+   Multiple Sites & Sub-URI <reference/multi-site-sub-uri>
+   Server API <reference/server-api>
 
 .. toctree::
    :hidden:
    :maxdepth: 1
    :caption: Technical documentation
 
-   Server <technical-docs/server.rst>
-   Client <technical-docs/client.rst>
-   Development & Testing <technical-docs/testing.rst>
-   Testing the Client <technical-docs/testing-client.rst>
-   Testing the Server <technical-docs/testing-server.rst>
+   Server <technical-docs/server>
+   Client <technical-docs/client>
+   Development & Testing <technical-docs/testing>
+   Testing the Client <technical-docs/testing-client>
+   Testing the Server <technical-docs/testing-server>
 
 .. toctree::
    :hidden:
    :maxdepth: 1
    :caption: Contributing
 
-   Contributing to Isso <contributing/index.rst>
-   Writing Documentation <contributing/documentation.rst>
+   Contributing to Isso <contributing/index>
+   Writing Documentation <contributing/documentation>

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -203,6 +203,7 @@ require-email = false
 # Misaka-specific Markdown extensions, all extensions can be used here,
 # separated by comma, either by their name or by EXT_<extension>.
 # Careful: Misaka 1.0 used "snake_case", but 2.0 needs "dashed-case"!
+# Explanation of extensions: https://flask-misaka.readthedocs.io/en/latest/#options
 options = strikethrough, superscript, autolink, fenced-code
 
 # Misaka-specific HTML rendering flags, all html rendering flags can be used


### PR DESCRIPTION
### docs: testing-client: Document Jest snapshots

### docs/contrib: doc: Add versionadded note, more links

### docs/contrib: Format 'complexity' section as hlist

Will be evenly distributed into two columns, easing readability and taking up less space

### docs: css: Use deeper blue for links

### docs: css: Style versionchanged, defn.-lists

Style `versionchanged`, `versionadded`, deprecated` directives to display e.g. "Changed in 0.12.6" with a slight yellow background.

Style definition lists to that titles stick out more.

### docs: client-conf: Use default dl, annotate added/deprecated

### docs: server-conf: Add defaults, clarify more

Some sections were a bit out of date or did not convey the intent to users properly.

Also correct styling (many markdown-style single backticks where reST needs double ones) and add some more structural elements.

### Minor nitpicking:

- `isso: isso.cfg: Add link for misaka exts`
- `docs: contrib: More links, clarification`
- `docs: toc: Remove superfluous file ext`
- `docs: css: Do not vertically center hlist items`
