### PR TITLE
[docs] Reduce width; code highlighting changes, installation guide improvements, prompt blocks

### DIFF
--- a/docs/_isso/layout.html
+++ b/docs/_isso/layout.html
@@ -91,7 +91,6 @@
             </header>
             <nav>
                 <a href="{{ pathto('docs') }}">Documentation</a>
-                <a href="{{ pathto('news') }}">News</a>
                 <a href="{{ pathto('docs/contributing') }}">Contribute</a>
                 <a href="{{ pathto('community') }}">community</a>
             </nav>

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -295,9 +295,9 @@ main {
     main .docs .highlight {
       margin: 1.2em 0;
       padding: 10px 15px;
-      background-color: #eeeeee;
-      color: #4d4d4c;
-      border: 1px solid #dddddd;
+      background-color: #f3f3f3;
+      color: #2f2f2f;
+      border: 1px solid #d3d3d3;
       border-radius: 4px;
       overflow: auto; }
     main .docs .headerlink {

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -300,6 +300,17 @@ main {
       border: 1px solid #d3d3d3;
       border-radius: 4px;
       overflow: auto; }
+      main .docs .highlight .gp {
+        /* gp: Generic.Prompt */
+        user-select: none;
+        -webkit-user-select: text;
+        /* Safari fallback only */
+        -webkit-user-select: none;
+        /* Chrome/Safari */
+        -moz-user-select: none;
+        /* Firefox */
+        -ms-user-select: none;
+        /* IE10+ */ }
     main .docs .headerlink {
       visibility: hidden; }
     main .docs p + p {

--- a/docs/_static/css/site.css
+++ b/docs/_static/css/site.css
@@ -33,7 +33,7 @@ body {
 
 .header {
   *zoom: 1;
-  max-width: 80em;
+  max-width: 70em;
   margin-left: auto;
   margin-right: auto;
   padding-top: 1em;
@@ -87,7 +87,7 @@ body {
   box-shadow: inset 0 0 0.5em #c0c0c0; }
   .outer header {
     *zoom: 1;
-    max-width: 80em;
+    max-width: 70em;
     margin-left: auto;
     margin-right: auto;
     padding: 1em 0; }
@@ -105,7 +105,7 @@ body {
       letter-spacing: 0.05em; }
   .outer footer {
     *zoom: 1;
-    max-width: 80em;
+    max-width: 70em;
     margin-left: auto;
     margin-right: auto; }
     .outer footer:before, .outer footer:after {
@@ -115,7 +115,7 @@ body {
       clear: both; }
   .outer .index {
     *zoom: 1;
-    max-width: 80em;
+    max-width: 70em;
     margin-left: auto;
     margin-right: auto;
     padding: 1em; }
@@ -162,7 +162,7 @@ body {
 
 main {
   *zoom: 1;
-  max-width: 80em;
+  max-width: 70em;
   margin-left: auto;
   margin-right: auto;
   margin-top: 1.6em;

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -9,6 +9,11 @@ $strong-blue: #6ab0de;
 $background-blue: #e7f2fa;
 $text: #2f2f2f;
 $muted-grey: #151515;
+
+$code-background-color: #eeeeee;
+$code-block-background-color: #f3f3f3;
+$code-block-border-color: #d3d3d3;
+
 $admon-todo: #f0b37e;
 $highlighted: #f1c40f;
 $versionchanged: lightyellow;
@@ -345,7 +350,7 @@ main {
 
     code {
       color: #002e40;
-      background-color: #eeeeee;
+      background-color: $code-background-color;
       padding: 0.2em 0.3em;
     }
 
@@ -353,10 +358,10 @@ main {
       margin: 1.2em 0;
       padding: 10px 15px;
 
-      background-color: rgb(238, 238, 238);
-      color: rgb(77, 77, 76);
+      background-color: $code-block-background-color;
+      color: $text;
 
-      border: 1px solid rgb(221, 221, 221);
+      border: 1px solid $code-block-border-color;
       border-radius: 4px;
       overflow: auto;
     }

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -2,7 +2,7 @@
 @import "neat/neat";
 
 // Override bourbon _grid.scss
-$max-width: em(1280); // Max-width of the outer container, divided by 16
+$max-width: em(1120); // Max-width of the outer container, divided by 16
 
 $blue: #2980b9;
 $strong-blue: #6ab0de;

--- a/docs/_static/css/site.scss
+++ b/docs/_static/css/site.scss
@@ -364,6 +364,16 @@ main {
       border: 1px solid $code-block-border-color;
       border-radius: 4px;
       overflow: auto;
+
+      // Make '$' at beginning of bash code blocks non-selectable
+      // See sphinx-rtd-theme: basic.css_t
+      .gp {  /* gp: Generic.Prompt */
+         user-select: none;
+         -webkit-user-select: text; /* Safari fallback only */
+         -webkit-user-select: none; /* Chrome/Safari */
+         -moz-user-select: none; /* Firefox */
+         -ms-user-select: none; /* IE10+ */
+      }
     }
 
     .headerlink {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,8 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'trac'
+# See https://pygments.org/styles/
+pygments_style = 'abap'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -31,7 +31,7 @@ You will need to have the latest version of the ``Sphinx`` documentation generat
 
 Install via pip:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ virtualenv .venv && $ source .venv/bin/activate
    (.venv) $ pip install sphinx
@@ -40,7 +40,7 @@ Install via pip:
 
 Build the docs:
 
-.. code-block:: bash
+.. code-block:: console
 
    (.venv) $ make site
 
@@ -51,7 +51,7 @@ If you have made any changes to the stylesheets, you need to install the
 `sassc`__ program and then re-generate the CSS file at
 ``docs/_static/css/site.css``:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ apt install sassc
    $ make css
@@ -130,7 +130,7 @@ Use ``.. code-block:: <language>`` and indent the code by one level:
 
 .. code-block:: rst
 
-   .. code-block:: bash
+   .. code-block:: console
 
         $ sudo apt install python3 python3-pip python3-virtualenv
         $ virtualenv .venv
@@ -144,12 +144,14 @@ Syntax standards
   ``===`` for page title, ``---`` for section headings (h3), ``^^^`` for
   sub-headings (h4).
 - Use ``$ /usr/bin/command`` to refer to shell commands and use
-  ``code-block:: bash`` over ``sh``
+  ``code-block:: console`` over ``bash`` or ``sh``.
+  For actual shell scripts, use ``sh``.
 - Use ``(.venv) $ python [cmd]`` for things that need to be run inside a
   virtual environment and be consistent
   (see `Sphinx: Narrative Documentation`__)
-- Use ``/path/to/isso/<thing>`` to refer to items inside Isso's main directory
-  and use ``comments.db`` as the name for the database
+- Use ``/path/to/isso/<thing>`` to refer to items inside Isso's installation
+  directory or for user data and use ``comments.db`` as the name for the
+  database
 - Admonitions should only be: ``note``, ``tip``, ``warning``, ``attention``,
   (maybe also ``error``?). See `docutils: Admonitions`__.
 - Try to keep line length under 80 characters, but don't worry when going over

--- a/docs/docs/guides/quickstart.rst
+++ b/docs/docs/guides/quickstart.rst
@@ -12,8 +12,8 @@ covered:
 Configuration
 -------------
 
-You must provide a custom configuration to set `dbpath` (your database
-location) and `host` (a list of websites for CORS_). All other options have
+You must provide a custom configuration to set ``dbpath`` (your database
+location) and ``host`` (a list of websites for CORS_). All other options have
 sane defaults.
 
 .. code-block:: ini
@@ -76,9 +76,9 @@ Try to repair the file using ``xmllint`` before you continue with the import.
 
 Now import the XML dump:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> isso -c /path/to/isso.cfg import -t [disqus|wordpress] disqus-or-wordpress.xml
+    (.venv) $ isso -c /path/to/isso.cfg import -t [disqus|wordpress] disqus-or-wordpress.xml
     [100%]  53 threads, 192 comments
 
 .. _Disqus: https://disqus.com/
@@ -89,9 +89,9 @@ Running Isso
 
 To run Isso, simply execute:
 
-.. code-block:: sh
+.. code-block:: console
 
-    $ isso -c /path/to/isso.cfg run
+    (.venv) $ isso -c /path/to/isso.cfg run
     2013-11-25 15:31:34,773 INFO: connected to HTTP server
 
 Next, we configure Nginx_ to proxy Isso. Do not run Isso on a public interface!

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -25,15 +25,14 @@ version – looking at you, Debian!).
 That's why most Python developers use the `Python Package Index`_ to get their
 dependencies. The most important rule to follow is to never install *anything* from PyPi
 as root. Not because of malicious software, but because you *will* break your
-system.
-``easy_install`` is one tool to mess up your system. Another package manager is
-``pip``. If you ever searched for an issue with Python/pip and Stackoverflow is
-suggesting you ``easy_install pip`` or ``pip install --upgrade pip`` (as root
+system. ``pip`` is one tool to mess up your system.
+If you ever searched for an issue with Python/pip and Stackoverflow is
+suggesting you ``pip install --upgrade pip`` (as root
 of course!), you are doing it wrong. `Why you should not use Python's
 easy_install carelessly on Debian`_ is worth the read.
 
 Fortunately, Python has a way to install packages (both as root and as user)
-without interfering with your globally installed packages: `virtualenv`. Use
+without interfering with your globally installed packages: ``virtualenv``. Use
 this *always* if you are installing software unavailable in your favourite
 package manager.
 
@@ -105,13 +104,7 @@ Install Isso with `pip <http://www.pip-installer.org/en/latest/>`_:
 
 .. code-block:: sh
 
-    ~> pip install isso
-
-`Don't have pip? <https://twitter.com/gardaud/status/357638468572151808>`_
-
-.. code-block:: sh
-
-    ~> easy_install isso  # cross your fingers
+    (.venv) $ pip install isso
 
 For easier execution, you can symlink the executable to a location in your
 :envvar:`PATH`.

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -39,10 +39,10 @@ package manager.
 .. code-block:: sh
 
     # for Debian/Ubuntu
-    ~> sudo apt-get install python-setuptools python-virtualenv python-dev
+    $ sudo apt-get install python3-setuptools python3-virtualenv python3-dev
 
     # Fedora/Red Hat
-    ~> sudo yum install python-setuptools python-virtualenv python-devel
+    $ sudo yum install python3-setuptools python3-virtualenv python3-devel
 
 The next steps should be done as regular user, not as root (although possible
 but not recommended):

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -158,9 +158,6 @@ way to set up Isso. It requires a lot more dependencies and effort:
 - SQLite 3.3.8 or later
 - a working C compiler
 - Node.js, `NPM <https://npmjs.org/>`__ - *required for frontend*
-- `sphinx <http://www.sphinx-doc.org/>`_,
-  `sassc <https://github.com/sass/sassc>`_ (for compiling
-  `.scss <https://sass-lang.com/>`_ to css) - *optional - only for docs*
 
 Get a fresh copy of Isso:
 
@@ -192,20 +189,8 @@ Install Isso and its dependencies:
 
 .. code-block:: sh
 
-    ~> python setup.py develop  # or `pip install -e .`
-    ~> isso run
-
-Install `sphinx <http://www.sphinx-doc.org/>`_ for generating docs:
-
-.. code-block:: sh
-
-    ~> pip install sphinx
-
-Generate docs:
-
-.. code-block:: sh
-
-    ~> make site
+    (.venv) $ python setup.py develop  # or `pip install -e .`
+    (.venv) $ isso -c /path/to/isso.cfg run
 
 .. _init-scripts:
 

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -36,7 +36,7 @@ without interfering with your globally installed packages: ``virtualenv``. Use
 this *always* if you are installing software unavailable in your favourite
 package manager.
 
-.. code-block:: sh
+.. code-block:: console
 
     # for Debian/Ubuntu
     $ sudo apt-get install python3-setuptools python3-virtualenv python3-dev
@@ -47,20 +47,24 @@ package manager.
 The next steps should be done as regular user, not as root (although possible
 but not recommended):
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> virtualenv /opt/isso
-    ~> source /opt/isso/bin/activate
+    $ virtualenv /opt/isso
+    $ source /opt/isso/bin/activate
 
-After calling `source`, you can now install packages from PyPi locally into this
-virtual environment. If you don't like Isso anymore, you just `rm -rf` the
+.. note::
+   This guide will refer to commands that need to run inside an activated
+   ``virtualenv`` with the ``(.venv) $`` prefix.
+
+After calling ``source``, you can now install packages from PyPi locally into this
+virtual environment. If you don't like Isso anymore, you just ``rm -rf`` the
 folder. Inside this virtual environment, you may also execute the example
 commands from above to upgrade your Python Package Manager (although it barely
 makes sense), it is completely independent from your global system.
 
 To use Isso installed in a virtual environment outside of the virtual
-environment, you just need to add */opt/isso/bin* to your :envvar:`PATH` or
-execute */opt/isso/bin/isso* directly. It will launch Isso from within the
+environment, you just need to add ``/opt/isso/bin`` to your :envvar:`PATH` or
+execute ``/opt/isso/bin/isso`` directly. It will launch Isso from within the
 virtual environment.
 
 With a virtualenv active, you may now continue to :ref:`install-from-pypi`!
@@ -86,42 +90,44 @@ Requirements
 For Debian/Ubuntu just `copy and paste
 <http://thejh.net/misc/website-terminal-copy-paste>`_ to your terminal:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> sudo apt-get install python3-dev sqlite3 build-essential
+    $ sudo apt-get install python3-dev sqlite3 build-essential
 
 Similar for Fedora (and derivates):
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> sudo yum install python3-devel sqlite
-    ~> sudo yum groupinstall “Development Tools”
+    $ sudo yum install python3-devel sqlite
+    $ sudo yum groupinstall “Development Tools”
 
 Installation
 ^^^^^^^^^^^^
 
-Install Isso with `pip <http://www.pip-installer.org/en/latest/>`_:
+Install Isso with `pip <http://www.pip-installer.org/en/latest/>`_, using the
+``virtualenv`` set up before:
 
-.. code-block:: sh
+.. code-block:: console
 
+    $ source /opt/isso/bin/activate
     (.venv) $ pip install isso
 
 For easier execution, you can symlink the executable to a location in your
 :envvar:`PATH`.
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> ln -s /opt/isso/bin/isso /usr/local/bin/isso
+    $ ln -s /opt/isso/bin/isso /usr/local/bin/isso
 
 Upgrade
 ^^^^^^^
 
 To upgrade Isso, activate your virtual environment again, and run
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> source /opt/isso/bin/activate  # optional
-    ~> pip install --upgrade isso
+    $ source /opt/isso/bin/activate  # optional
+    (.venv) $ pip install --upgrade isso
 
 .. _prebuilt-package:
 
@@ -135,13 +141,13 @@ Prebuilt Packages
 Build a Docker image
 --------------------
 
-You can get a Docker image by running ``docker build . -t
-isso``. Assuming you have your configuration in ``/opt/isso``, you can
-use the following command to spawn the Docker container:
+You can get a Docker image by running ``docker build . -t isso``.
+Assuming you have your configuration in ``/opt/isso``, you can use the
+following command to spawn the Docker container:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> docker run -d --rm --name isso -p 127.0.0.1:8080:8080 -v /opt/isso:/config -v /opt/isso:/db isso
+    $ docker run -d --rm --name isso -p 127.0.0.1:8080:8080 -v /opt/isso:/config -v /opt/isso:/db isso
 
 Then, you can use a reverse proxy to expose port 8080.
 
@@ -161,33 +167,33 @@ way to set up Isso. It requires a lot more dependencies and effort:
 
 Get a fresh copy of Isso:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> git clone https://github.com/posativ/isso.git
-    ~> cd isso/
+    $ git clone https://github.com/posativ/isso.git
+    $ cd isso/
 
 To create a virtual environment (recommended), run:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> virtualenv .
-    ~> source ./bin/activate
+    $ virtualenv .venv
+    $ source .venv/bin/activate
 
 Install JavaScript modules using ``npm``:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> make init
+    $ make init
 
 Build JavaScript frontend code:
 
-.. code-block:: sh
+.. code-block:: console
 
-    ~> make js
+    $ make js
 
 Install Isso and its dependencies:
 
-.. code-block:: sh
+.. code-block:: console
 
     (.venv) $ python setup.py develop  # or `pip install -e .`
     (.venv) $ isso -c /path/to/isso.cfg run

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -153,10 +153,10 @@ Install from Source
 If you want to hack on Isso or track down issues, there's an alternate
 way to set up Isso. It requires a lot more dependencies and effort:
 
-- Python 3.5+ (+ devel headers)
+- Python 3.6+ (+ devel headers)
 - Virtualenv
 - SQLite 3.3.8 or later
-- a working C compiler
+- a working C compiler (e.g. the ``gcc`` package)
 - Node.js, `NPM <https://npmjs.org/>`__ - *required for frontend*
 
 Get a fresh copy of Isso:


### PR DESCRIPTION
### docs: css: Reduce content width to 70em

Was 80em, but that leaves too high line lengths.

### docs: theme: Remove 'News' navlink

Not really useful at the moment, might get added back later.

### docs: conf: Use abap pygments style

The "trac" pygments style is not as readable and doesn't fit as well with the overall blue-ish white theme.

### docs: css: Lighter code bg, use vars

### docs: install: Remove mentions of easy_install

`easy_install` has ceased enough in popularity that it'd just be confusing to mention.

### docs: install: Explicitly mention py3 packages

Aligns with below sections in the document. Isso is py3-only.

### docs: install: Drop docs instructions

Those have been moved to the "Writing documentation" section and clutter the installation guide unnecessarily - especially since the manpage generation was been removed.

### [nit] docs: install: Bump py to 3.6 in from-source

### docs: install, quickstart: Unify venv/shell syntax

Use `$` instead of `~>` for consistency and use the `(.venv) $` prefix to denote commands that need to be run inside a virtualenv.

Also converge on using `console` as a block "language" so that the "prompt" characters such as `$` are rendered as not user-selectable, easing copy-paste.

### docs/contrib: docs: Use and document console blocks

### docs: css: Make console prompts non-selectable

"Prompt" characters such as `$` are rendered as not user-selectable, easing copy-paste.
