### PR TITLE
[server] Re-enable no-intra-emphasis Markdown ext, allow sub/sup elms by default, src if img

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog for Isso
   whether or not the subscribe to replies checkbox should be checked by default.
 - Accessibility: Use labels rather than placeholders for name, email & website
   in post box (`#861 <https://github.com/posativ/isso/pull/861>`_, ix5)
+- Re-enable ``no-intra-emphasis`` misaka extension in default config.
 
 .. _Gravatar: Image requests: http://en.gravatar.com/site/implement/images/
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog for Isso
 - Accessibility: Use labels rather than placeholders for name, email & website
   in post box (`#861 <https://github.com/posativ/isso/pull/861>`_, ix5)
 - Re-enable ``no-intra-emphasis`` misaka extension in default config.
+- Allow ``sup`` and ``sub`` HTML elements by default
 
 .. _Gravatar: Image requests: http://en.gravatar.com/site/implement/images/
 

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -204,7 +204,7 @@ require-email = false
 # separated by comma, either by their name or by EXT_<extension>.
 # Careful: Misaka 1.0 used "snake_case", but 2.0 needs "dashed-case"!
 # Explanation of extensions: https://flask-misaka.readthedocs.io/en/latest/#options
-options = strikethrough, superscript, autolink, fenced-code
+options = autolink, fenced-code, no-intra-emphasis, strikethrough, superscript
 
 # Misaka-specific HTML rendering flags, all html rendering flags can be used
 # here, separated by comma, either by their name or as HTML_<flag>.

--- a/isso/utils/html.py
+++ b/isso/utils/html.py
@@ -10,14 +10,14 @@ class Sanitizer(object):
 
     def __init__(self, elements, attributes):
         # attributes found in Sundown's HTML serializer [1]
-        # except for <img> tag,
-        # because images are not generated anyways.
+        # - except for <img> tag, because images are not generated anyways.
+        # - sub and sup added
         #
         # [1] https://github.com/vmg/sundown/blob/master/html/html.c
         self.elements = ["a", "p", "hr", "br", "ol", "ul", "li",
                          "pre", "code", "blockquote",
                          "del", "ins", "strong", "em",
-                         "h1", "h2", "h3", "h4", "h5", "h6",
+                         "h1", "h2", "h3", "h4", "h5", "h6", "sub", "sup",
                          "table", "thead", "tbody", "th", "td"] + elements
 
         # href for <a> and align for <table>

--- a/isso/utils/html.py
+++ b/isso/utils/html.py
@@ -48,8 +48,8 @@ class Sanitizer(object):
         return linker.linkify(clean_html)
 
 
-def Markdown(extensions=("strikethrough", "superscript", "autolink",
-                         "fenced-code"), flags=[]):
+def Markdown(extensions=("autolink", "fenced-code", "no-intra-emphasis",
+                         "strikethrough", "superscript"), flags=[]):
 
     renderer = Unofficial(flags=flags)
     md = misaka.Markdown(renderer, extensions=extensions)

--- a/isso/utils/html.py
+++ b/isso/utils/html.py
@@ -92,6 +92,10 @@ class Markup(object):
         # Filter out empty strings:
         allowed_elements = [x for x in conf.getlist("allowed-elements") if x]
         allowed_attributes = [x for x in conf.getlist("allowed-attributes") if x]
+
+        # If images are allowed, source element should be allowed as well
+        if 'img' in allowed_elements and 'src' not in allowed_attributes:
+            allowed_attributes.append('src')
         sanitizer = Sanitizer(allowed_elements, allowed_attributes)
 
         self._render = lambda text: sanitizer.sanitize(parser(text))

--- a/share/isso-dev.cfg
+++ b/share/isso-dev.cfg
@@ -31,7 +31,7 @@ profile = off
 enabled = false
 
 [markup]
-options = strikethrough, autolink, fenced-code, no-intra-emphasis
+options = autolink, fenced-code, no-intra-emphasis, strikethrough, superscript
 flags =
 allowed-elements =
 allowed-attributes =


### PR DESCRIPTION
### isso.cfg, utils/html: Re-enable no-intra-emphasis md ext

The commit 72e624bf6aeaeffa03a26f7d258561269ae54eec "share: isso.conf: Use dashed-case for misaka 2.0" removed the misaka extension `no-intra-emphasis`, mistakenly. Add it back again.

Also correct the (mostly unused) default options in utils/html.py and add a CHANGES entry.

### utils/html: Allow sup and sub elements by default

The `superscript` extension was enabled by default and it might have been confusing for commenters as well as admins why their x^2 did not render correctly.

### utils/html: Allow src attr if img elm allowed

This is just a minor qualify-of-life improvement. If admins choose to enable the (not-enabled-by-default) `<img>` tag, they most likely also want `src=...` to be enabled as well.