### PR TITLE
js: count: Don't send `/count` request if there are no counters

### DIFF
--- a/isso/js/app/count.js
+++ b/isso/js/app/count.js
@@ -24,16 +24,18 @@ module.exports = function () {
 
     var urls = Object.keys(objs);
 
-    api.count(urls).then(function(rv) {
-        for (var key in objs) {
-            if (objs.hasOwnProperty(key)) {
+    if (urls.length > 0) {
+        api.count(urls).then(function(rv) {
+            for (var key in objs) {
+                if (objs.hasOwnProperty(key)) {
 
-                var index = urls.indexOf(key);
+                    var index = urls.indexOf(key);
 
-                for (var i = 0; i < objs[key].length; i++) {
-                    objs[key][i].textContent = i18n.pluralize("num-comments", rv[index]);
+                    for (var i = 0; i < objs[key].length; i++) {
+                        objs[key][i].textContent = i18n.pluralize("num-comments", rv[index]);
+                    }
                 }
             }
-        }
-    });
+        });
+    }
 };


### PR DESCRIPTION
Fixes #771

Tasks:

- [ ] CHANGES.rst
- [ ] Docs? maybe none are needed
- [ ] Investigate returning a 400 when /count is called without any URLs
- [ ] Docs probably needs to have `POST /count` documented, that would be another PR
- [ ] Tests