### PR TITLE
[client] Fix avatar sizing on Chrome & Safari

### DIFF
--- a/isso/css/isso.css
+++ b/isso/css/isso.css
@@ -51,6 +51,8 @@
 .isso-comment > .isso-avatar > svg {
     max-width: 48px;
     max-height: 48px;
+    width: 100%;
+    height: 100%;
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 3px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Before this change, on Chrome and Safari (but not Firefox), the `svg` inside `.isso-avatar` has a size of 0 by 0 pixels. Not sure why it worked on Firefox, but this makes sense because svg's have no native size, and since there was no minimum size specified, it defaulted to 0.

Instead of just setting `width` to `48px`, I set it to `100%` and left `max-width` set to `48px`. [It should be better practice this way](https://css-tricks.com/tale-width-max-width/).

I am wondering if setting `height` is a good idea, since it seems to have no effect. I kept it in just because it's clearer.

## Before (demo on Chromium)

![the avatar image is seemingly blank as it has a size of zero pixels](https://user-images.githubusercontent.com/17971474/167511609-261ca444-6c1e-4a7d-b688-2341e18830ca.png)

## After

![the avatar is displayed properly, with a size of 48x48 px](https://user-images.githubusercontent.com/17971474/167511706-37f3d2f9-4289-470e-a6da-44e51d1c0569.png)
