### PR TITLE
[server] Strip trailing slash from public-endpoint, disallow trailing slash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Changelog for Isso
   - Add ``/config`` endpoint for fetching server configuration options that
     affect the client
   - Remove ``/count`` GET endpoint (use POST instead)
+- Strip trailing slash from public-endpoint, allow trailing slashes for routes.
+  A trailing slash in ``[server] public-endpoint`` is now discouraged and
+  throws a warning (#876, ix5)
 
 - Replace ``contenteditable`` ``div`` with ``textarea`` to fix issues when
   editing messages that contain indented code

--- a/docs/docs/reference/server-config.rst
+++ b/docs/docs/reference/server-config.rst
@@ -215,11 +215,17 @@ listen
 
 public-endpoint
     Public URL that Isso is accessed from by end users. Should always be
-    a http:// or https:// absolute address. If left blank, automatic
-    detection is attempted. Normally only needs to be specified if
-    different than the ``listen`` setting.
+    a ``http://`` or ``https://`` absolute address. If left blank, automatic
+    detection is attempted. Normally only needs to be specified if different
+    than the ``listen`` setting.
+
+    This URL must not end in a ``/`` slash, i.e. ``http://foo.bar:8080/`` is
+    forbidden but ``http://foo/bar:8080`` is fine.
 
     Default: (empty)
+
+    .. versionchanged:: 0.13
+        Trailing slash now forbidden.
 
 reload
     Reload application, when the source code has changed. Useful for

--- a/isso/config.py
+++ b/isso/config.py
@@ -114,6 +114,9 @@ class IssoParser(ConfigParser):
             if item:
                 yield item
 
+    def set(self, section, key, value):
+        super(IssoParser, self).set(section, key, value)
+
     def section(self, section):
         return Section(self, section)
 
@@ -170,5 +173,16 @@ def load(default, user=None):
     if not parseaddr(fromaddr)[0]:
         parser.set("smtp", "from",
                    formataddr(("Ich schrei sonst!", fromaddr)))
+
+    # Warn on trailing slash which can result in malformed double-slashed URLs
+    if parser.get("server", "public-endpoint").endswith("/"):
+        public_endpoint = parser.get("server", "public-endpoint")
+        logger.warn("In your config file, '[server] public-endpoint' has a slash at the end, "
+                    "please remove it: '%s' -> '%s'",
+                    public_endpoint, public_endpoint.rstrip("/"))
+        # XXX Actually fail here in a future version
+        logger.warn("A future version of Isso might quit with an error if 'public-endpoint' is set incorrectly")
+        # Remove trailing slash
+        parser.set("server", "public-endpoint", public_endpoint.rstrip("/"))
 
     return parser

--- a/isso/tests/test_guard.py
+++ b/isso/tests/test_guard.py
@@ -4,7 +4,6 @@ import json
 import tempfile
 import unittest
 
-from werkzeug import __version__
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
@@ -13,12 +12,6 @@ from isso.utils import http
 
 from fixtures import curl, FakeIP
 http.curl = curl
-
-if __version__.startswith("0.8"):
-    class Response(Response):
-
-        def get_data(self, as_text=False):
-            return self.data.decode("utf-8")
 
 
 class TestGuard(unittest.TestCase):


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

### isso: config: Strip trailing public-endpoint slash

Fixes https://github.com/posativ/isso/issues/498

### docs: server-conf: public-endpoint trailing '/' forbidden

Starting in 0.13, a trailing slash in `[server] public-endpoint` is now discouraged and throws a warning.

### tests: guard: Remove obsolete werkzeug 0.8 check

---

# Other considerations
Ideally, we should strip the trailing slash automatically from *any* config value that contains a URL, and be consistent with examples in docs, example config files.