### PR TITLE
[server] Add /config endpoint

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ on:
       - "setup.py"
       - "setup.cfg"
       - "contrib/**.py"
-      - "isso/js/**.py"
+      - "isso/**.py"
       - ".github/workflows/python-tests.yml"
 
 jobs:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Changelog for Isso
   to style comments and replies made by the page's author(s).
 - Add Ukrainian localisation (`#878`_, okawo80085)
 - Enable Turkish localisation (`#879`_, okawo80085)
+- Add ``/config`` endpoint for fetching server configuration options that
+  affect the client
 
 .. _Gravatar: Image requests: http://en.gravatar.com/site/implement/images/
 .. _879: https://github.com/posativ/isso/pull/879

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -107,6 +107,7 @@ class API(object):
         ('dislike', ('POST', '/id/<int:id>/dislike')),
         ('demo', ('GET', '/demo')),
         ('preview', ('POST', '/preview')),
+        ('config', ('GET', '/config')),
         ('login', ('POST', '/login')),
         ('admin', ('GET', '/admin'))
     ]
@@ -1114,6 +1115,41 @@ class API(object):
             raise BadRequest("no text given")
 
         return JSON({'text': self.isso.render(data["text"])}, 200)
+
+    """
+    @api {get} /config fetch client config
+    @apiGroup Thread
+    @apiDescription
+        Returns only the client configuration parameters that depend on server settings. The following settings are sent as a `config` object from the server to the client:
+
+            reply-to-self
+            require-author
+            require-email
+            reply-notifications
+            gravatar
+            avatar  # if gravatar==true
+
+    @apiSuccess {Object[]} config
+        The client configuration object.
+
+    @apiExample {curl} get the client config:
+        curl 'https://comments.example.com/config'
+
+    @apiSuccessExample Client config:
+        {
+          "config": {
+            "reply-to-self": false,
+            "require-email": false,
+            "require-author": false,
+            "reply-notifications": false,
+            "gravatar": true
+            "avatar": false
+          }
+        }
+    """
+    def config(self, environment, request):
+        rv = {'config': self.public_conf}
+        return JSON(rv, 200)
 
     def demo(self, env, req):
         return redirect(


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
Add `/config` endpoint which returns the same data as the `config` object of the `/` GET endpoint. This endpoint is unused by the current client but useful for development and will be utilized in the future.

A partial re-send of https://github.com/posativ/isso/pull/821


## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
This PR prepares work for fetching the configuration from a dedicated endpoint *before* fetching any comments or inserting a postbox. Instead of fixing all the issues that pop up in #821 immediately, merge this partial (currently unused) feature already and then start work on ironing out client bugs.