### PR TITLE
[client] Minor client bugfixes

### DIFF
--- a/isso/js/app/api.js
+++ b/isso/js/app/api.js
@@ -157,8 +157,6 @@ var fetch = function(tid, limit, nested_limit, parent, lastcreated) {
         qs(query_dict), null, function(rv) {
             if (rv.status === 200) {
                 deferred.resolve(JSON.parse(rv.body));
-            } else if (rv.status === 404) {
-                deferred.resolve({total_replies: 0});
             } else {
                 deferred.reject(rv.body);
             }

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -93,7 +93,9 @@ function fetchComments() {
 
             // Note: isso.Postbox relies on the config object populated by elements
             // fetched from the server, so it cannot be created in init()
-            isso_root.prepend(new isso.Postbox(null));
+            // DOM polyfill prepend() will insert the element before the first
+            // child, not before the element itself!
+            isso_root.obj.parentElement.insertBefore(new isso.Postbox(null).obj, isso_root.obj);
 
             if (rv.total_replies === 0) {
                 heading.textContent = i18n.translate("no-comments");

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -65,7 +65,11 @@ function init() {
             existingTarget.classList.remove("isso-target");
         }
 
-        $(window.location.hash + " > .isso-text-wrapper").classList.add("isso-target");
+        try {
+            $(window.location.hash + " > .isso-text-wrapper").classList.add("isso-target");
+        } catch(ex) {
+            // selector probably doesn't exist as element on page
+        }
     });
 }
 
@@ -119,12 +123,16 @@ function fetchComments() {
 
             if (window.location.hash.length > 0 &&
                 window.location.hash.match("^#isso-[0-9]+$")) {
-                $(window.location.hash).scrollIntoView();
+                try {
+                    $(window.location.hash).scrollIntoView();
 
-                // We can't just set the id to `#isso-target` because it's already set to `#isso-[number]`
-                // So a class `.isso-target` has to be used instead, and then we can manually remove the
-                // class from the old target comment in the `hashchange` listener.
-                $(window.location.hash + " > .isso-text-wrapper").classList.add("isso-target");
+                    // We can't just set the id to `#isso-target` because it's already set to `#isso-[number]`
+                    // So a class `.isso-target` has to be used instead, and then we can manually remove the
+                    // class from the old target comment in the `hashchange` listener.
+                    $(window.location.hash + " > .isso-text-wrapper").classList.add("isso-target");
+                } catch(ex) {
+                    // selector probably doesn't exist as element on page
+                }
             }
         },
         function(err) {

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -166,6 +166,15 @@ class TestComments(unittest.TestCase):
         data = loads(self.get('/?uri=?uri=%foo%2F').data)
         self.assertEqual(len(data['replies']), 0)
 
+    def testFetchEmpty(self):
+
+        empty = self.get('/?uri=%2Fempty%2F')
+        # Empty database returns 200, not 404
+        self.assertEqual(empty.status_code, 200)
+        data = loads(empty.data)
+        self.assertEqual(data['total_replies'], 0)
+        self.assertEqual(data['id'], None)
+
     def testGetLimited(self):
 
         for i in range(20):


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
- js: embed: Make Postbox sibling, not child of #isso-root
- js: embed: Catch nonexistent hash selectors
  We do not want to crash the whole app if a selector is not present.
- [nit] js: api: fetch: Remove 404 handling
  Isso returns a JSON response with `total_replies=0` instead of a 404 since version 0.12.3 (see troubleshooting, PR #565)
- tests: comments: Add test for HTTP 200 on empty db


## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
State previously, on 0.12.5:
```
<#isso-thread>
    <h2>
    <.postbox>
    <#isso-root>
```
Then, because configs needed to be fetched before rendering the postbox because of: 02f3ea06
This was the state in 0.12.6:
```
<#isso-thread>
    <h2>
    <#isso-root>
    <.postbox>
```

But that left the order of `#isso-root` and the `postbox` wrong, the box was displayed *after* the comment list

The hotfix release 0.12.6.1: 861f64f1 tried to rectify this, but it resulted in the following
state:
```
<#isso-thread>
    <h2>
    <#isso-root>
        <.postbox>
```

This commit restores the state as it was:
```
<#isso-thread>
    <h2>
    <.postbox>
    <#isso-root>
```
