### PR TITLE
[server] core: Replace flask-caching dependency with drop-in

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog for Isso
 - Re-enable ``no-intra-emphasis`` misaka extension in default config.
 - Allow ``sup`` and ``sub`` HTML elements by default
 - Move ``isso-dev.cfg`` to ``contrib/`` folder
+- Drop ``Flask-Caching`` dependency and use drop-in solution instead
 - Run automated screenshot comparisons for testing (`#889`_)
 - wsgi: Return HTTP errors as JSON if client prefers it (`#488`_, sundbry)
 - Add ``data-isso-page-author-hashes`` option to client which makes it possible

--- a/isso/core.py
+++ b/isso/core.py
@@ -12,8 +12,8 @@ except ImportError:
 
 import _thread as thread
 
-from flask_caching.backends.nullcache import NullCache
-from flask_caching.backends.simplecache import SimpleCache
+from isso.utils.cache import NullCache
+from isso.utils.cache import SimpleCache
 
 logger = logging.getLogger("isso")
 

--- a/isso/utils/cache.py
+++ b/isso/utils/cache.py
@@ -1,0 +1,138 @@
+import pickle
+from time import time
+
+# Imported from cachelib: https://github.com/pallets-eco/cachelib
+# As of v0.7.0, commit 4e23926effc41303c9e305663eafa81192442241
+# License: BSD 3-Clause, Copyright 2018 Pallets
+
+# BaseSerializer and SimpleSerializer: src/cachelib/serializers.py
+# BaseCache and NullCache: src/cachelib/base.py
+# SimpleCache: src/cachelib/simple.py
+# Type hints and unused functions removed
+
+
+class BaseSerializer:
+    """BaseSerializer.loads and BaseSerializer.dumps
+    work on top of pickle.loads and pickle.dumps. Dumping/loading
+    strings and byte strings is the default for most cache types.
+    """
+
+    def dumps(self, value, protocol=pickle.HIGHEST_PROTOCOL):
+        try:
+            serialized = pickle.dumps(value, protocol)
+        except (pickle.PickleError, pickle.PicklingError) as e:
+            self._warn(e)
+        return serialized
+
+    def loads(self, bvalue):
+        try:
+            data = pickle.loads(bvalue)
+        except pickle.PickleError as e:
+            self._warn(e)
+            return None
+        else:
+            return data
+
+
+class SimpleSerializer(BaseSerializer):
+    """Default serializer for SimpleCache."""
+
+
+class BaseCache:
+    def __init__(self, default_timeout: int = 300):
+        self.default_timeout = default_timeout
+
+    def _normalize_timeout(self, timeout):
+        if timeout is None:
+            timeout = self.default_timeout
+        return timeout
+
+    def get(self, key):
+        return None
+
+    def delete(self, key):
+        return True
+
+    def set(self, key, value, timeout=None):
+        return True
+
+
+class NullCache(BaseCache):
+    pass
+
+
+class SimpleCache(BaseCache):
+
+    """Simple memory cache for single process environments.  This class exists
+    mainly for the development server and is not 100% thread safe.  It tries
+    to use as many atomic operations as possible and no locks for simplicity
+    but it could happen under heavy load that keys are added multiple times.
+
+    :param threshold: the maximum number of items the cache stores before
+                      it starts deleting some.
+    :param default_timeout: the default timeout that is used if no timeout is
+                            specified on :meth:`~BaseCache.set`. A timeout of
+                            0 indicates that the cache never expires.
+    """
+
+    serializer = SimpleSerializer()
+
+    def __init__(
+        self,
+        threshold: int = 500,
+        default_timeout: int = 300,
+    ):
+        BaseCache.__init__(self, default_timeout)
+        self._cache = {}
+        self._threshold = threshold or 500  # threshold = 0
+
+    def _over_threshold(self):
+        return len(self._cache) > self._threshold
+
+    def _remove_expired(self, now):
+        toremove = [k for k, (expires, _) in self._cache.items() if expires < now]
+        for k in toremove:
+            self._cache.pop(k, None)
+
+    def _remove_older(self):
+        k_ordered = (
+            k
+            for k, v in sorted(
+                self._cache.items(), key=lambda item: item[1][0]
+            )
+        )
+        for k in k_ordered:
+            self._cache.pop(k, None)
+            if not self._over_threshold():
+                break
+
+    def _prune(self):
+        if self._over_threshold():
+            now = time()
+            self._remove_expired(now)
+        # remove older items if still over threshold
+        if self._over_threshold():
+            self._remove_older()
+
+    def _normalize_timeout(self, timeout):
+        timeout = BaseCache._normalize_timeout(self, timeout)
+        if timeout > 0:
+            timeout = int(time()) + timeout
+        return timeout
+
+    def get(self, key):
+        try:
+            expires, value = self._cache[key]
+            if expires == 0 or expires > time():
+                return self.serializer.loads(value)
+        except KeyError:
+            return None
+
+    def set(self, key, value, timeout=None):
+        expires = self._normalize_timeout(timeout)
+        self._prune()
+        self._cache[key] = (expires, self.serializer.dumps(value))
+        return True
+
+    def delete(self, key):
+        return self._cache.pop(key, None) is not None

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from re import sub as re_sub
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
-            'werkzeug>=1.0', 'bleach', 'Flask-Caching>=1.9', 'Flask']
+            'werkzeug>=1.0', 'bleach']
 tests_require = ['pytest', 'pytest-cov']
 
 # https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
### core: Replace flask-caching dep with drop-in

Instead of relying on flask-caching and its dep cachelib, import a trimmed-down version into the repo as `utils/cache.py`.

## Why is this necessary?
While seeing https://github.com/pallets-eco/flask-caching/pull/352 that currently breaks Isso, it became apparent that `Flask-Caching` has grown way too large and has gained dependencies of its own.

Initially, Isso depended on `SimpleCache` and `NullCache` from `werkzeug.contrib`, which meant that it didn't have to import any new dependencies. In a later version, caching was removed from werkzeug and instead pushed into its own package, which Isso then had to import.
With the newest release of `Flask-Caching`, there's now a hard dependency on `cachelib` as well, in addition to `flask`.

Isso only uses `get()`, `set()` and `delete()` cache functions and only for email/website hashes. We can drop all those dependencies and instead import a slimmed-down version on our own.