### PR TITLE
[server] views: comments: Check using get(), not 'in'

### DIFF
--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -472,6 +472,17 @@ class TestComments(unittest.TestCase):
         self.assertEqual(
             rv["text"], '<p>This is <strong>mark</strong><em>down</em></p>')
 
+    def testTitleNull(self):
+        # Thread title set to `null` in API request
+        # Javascript `null` equals Python `None`
+        self.post('/new?uri=%2Fpath%2F',
+                  data=json.dumps({'text': 'Spam', 'title': None}))
+
+        thread = self.app.db.threads.get(1)
+        # Expect server to attempt to parse uri to extract title
+        # utils.parse cannot parse fake /path/, so default="Untitled."
+        self.assertEqual(thread.get('title'), "Untitled.")
+
     def testLatestOk(self):
         # load some comments in a mix of posts
         saved = []

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -152,7 +152,7 @@ class API(object):
     @classmethod
     def verify(cls, comment):
 
-        if "text" not in comment:
+        if comment.get("text") is None:
             return False, "text is missing"
 
         if not isinstance(comment.get("parent"), (int, type(None))):
@@ -290,7 +290,7 @@ class API(object):
 
         with self.isso.lock:
             if uri not in self.threads:
-                if 'title' not in data:
+                if not data.get('title'):
                     with http.curl('GET', local("origin"), uri) as resp:
                         if resp and resp.status == 200:
                             uri, title = parse.thread(resp.read(), id=uri)
@@ -484,7 +484,7 @@ class API(object):
 
         data = request.json
 
-        if "text" not in data or data["text"] is None or len(data["text"]) < 3:
+        if data.get("text") is None or len(data["text"]) < 3:
             raise BadRequest("no text given")
 
         for key in set(data.keys()) - set(["text", "author", "website"]):
@@ -1031,7 +1031,7 @@ class API(object):
     def preview(self, environment, request):
         data = request.json
 
-        if "text" not in data or data["text"] is None:
+        if data.get("text", None) is None:
             raise BadRequest("no text given")
 
         return JSON({'text': self.isso.render(data["text"])}, 200)


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
Previously, if a dict item was supplied by the JS client but contained an invalid value such as `null`, the server would only check if the dict key was provided, not if its value was falsy.

```python
>>> mydict = dict(a='hi', b=None)
>>> 'b' in mydict
True
>>> 'b' not in mydict
False
```

Instead, use `.get()` and check if the value is empty. Then, for instance, attempt to parse thread uris if payload title is invalid instead of simply accepting `null` as thread title.

Also add a test to check this behavior.


## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Fixes: https://github.com/posativ/isso/issues/874
