### PR TITLE
migrate: Handle single newlines in WordPress comments as line breaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,10 @@ Breaking Changes
 Bugfixes & Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-- TBD
+- When importing from WordPress single newlines are now converted to line breaks
+  (`#903`_, projectgus)
 
+.. _#903: https://github.com/posativ/isso/pull/903
 
 0.13.0.beta1 (2022-06-05)
 -------------------------

--- a/isso/migrate.py
+++ b/isso/migrate.py
@@ -225,9 +225,18 @@ class WordPress(object):
         progress.finish("{0} threads, {1} comments".format(
             len(items) - skip, self.count))
 
+    def _process_comment_content(self, text):
+        # WordPress comment text renders a single newline between two blocks of
+        # text as a <br> tag, so add an explicit Markdown line break on import
+        # (Otherwise multiple blocks of text separated by single newlines are
+        # all shown as one long line.)
+        text = re.sub(r'(?!^\n)\n(?!^\n)', '  \n', text, 0)
+
+        return strip(text)
+
     def Comment(self, el):
         return {
-            "text": strip(el.find(self.ns + "comment_content").text),
+            "text": self._process_comment_content(el.find(self.ns + "comment_content").text),
             "author": strip(el.find(self.ns + "comment_author").text),
             "email": strip(el.find(self.ns + "comment_author_email").text),
             "website": strip(el.find(self.ns + "comment_author_url").text),

--- a/isso/tests/test_migration.py
+++ b/isso/tests/test_migration.py
@@ -87,7 +87,7 @@ class TestMigration(unittest.TestCase):
         self.assertEqual(
             len(db.execute("SELECT id FROM threads").fetchall()), 2)
         self.assertEqual(
-            len(db.execute("SELECT id FROM comments").fetchall()), 7)
+            len(db.execute("SELECT id FROM comments").fetchall()), 8)
 
         first = db.comments.get(1)
         self.assertEqual(first["author"], "Ohai")
@@ -101,7 +101,11 @@ class TestMigration(unittest.TestCase):
         for i in (3, 4, 5):
             self.assertEqual(db.comments.get(i)["parent"], second["id"])
 
-        last = db.comments.get(6)
+        # Ensure newlines in wordpress translate to two newlines in isso, to render the same
+        multiline = db.comments.get(6)
+        self.assertIn("multiple lines:  \nWordPress", multiline["text"])
+
+        last = db.comments.get(7)
         self.assertEqual(last["author"], "Letzter :/")
         self.assertEqual(last["parent"], None)
 

--- a/isso/tests/wordpress.xml
+++ b/isso/tests/wordpress.xml
@@ -101,13 +101,29 @@
             </wp:comment>
             <wp:comment>
                 <wp:comment_id>10</wp:comment_id>
+                <wp:comment_author><![CDATA[Multiline Author]]></wp:comment_author>
+                <wp:comment_author_email>multiline@example.org
+                </wp:comment_author_email>
+                <wp:comment_author_url></wp:comment_author_url>
+                <wp:comment_author_IP>::ffff:86.52.1.0</wp:comment_author_IP>
+                <wp:comment_date>2022-06-06 12:13:14</wp:comment_date>
+                <wp:comment_date_gmt>2022-06-06 02:13:14</wp:comment_date_gmt>
+                <wp:comment_content><![CDATA[When you have a comment with multiple lines:
+WordPress exports it like this.]]></wp:comment_content>
+                <wp:comment_approved>1</wp:comment_approved>
+                <wp:comment_type></wp:comment_type>
+                <wp:comment_parent>0</wp:comment_parent>
+                <wp:comment_user_id>1</wp:comment_user_id>
+            </wp:comment>
+            <wp:comment>
+                <wp:comment_id>11</wp:comment_id>
                 <wp:comment_author><![CDATA[Letzter :/]]></wp:comment_author>
                 <wp:comment_author_email>info@posativ.org
                 </wp:comment_author_email>
                 <wp:comment_author_url></wp:comment_author_url>
                 <wp:comment_author_IP>::ffff:86.56.63.0</wp:comment_author_IP>
-                <wp:comment_date>2014-04-29 15:21:56</wp:comment_date>
-                <wp:comment_date_gmt>2014-04-29 15:21:56</wp:comment_date_gmt>
+                <wp:comment_date>2022-06-07 15:21:56</wp:comment_date>
+                <wp:comment_date_gmt>2022-06-07 15:21:56</wp:comment_date_gmt>
                 <wp:comment_content><![CDATA[...]]></wp:comment_content>
                 <wp:comment_approved>1</wp:comment_approved>
                 <wp:comment_type></wp:comment_type>


### PR DESCRIPTION
WordPress renders a single newline in a comment as a <br> tag, but Isso renders a single newline in the comment as a single newline in the HTML. This is rendered the same as if it was a space, all text on one line.

To fix, detect single newlines when importing WordPress comments and convert to a line break in Markdown. Add a test for this also.

Example, this WordPress comment (as shown in CDATA of XML export):

> First line of comment.
> Second line of comment.

Renders in WordPress as:

> First line of comment.<br>Second line of comment.

But renders in Isso after import as if it was:

> First line of comment. Second line of comment.

After this commit is applied and comments re-imported, it renders as:

> First line of comment.
> Second line of comment.

<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- (N/A) (If docs changes needed:) I have updated the **documentation** accordingly.
- (N/A but please tell me if you disagree) I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->