### PR TITLE
Dockerfile: Explictly create volume paths and set permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ COPY --from=isso-builder /isso/ .
 # Clean up
 RUN rm -rf /var/apk/cache/* /tmp/* /var/tmp/*
 
+# Setup permissions for volume mounts
+RUN mkdir /db /config && chmod 1777 /db /config
+
 # Configuration
 VOLUME /db /config
 EXPOSE 8080


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [X] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [X] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?

This change explicitly creates the volume mount directories in the docker image and gives them global write permissions (`1777`).

## Why is this necessary?

This allows the docker images to be use named/anonymous volumes (e.g `-v /db` or `-v isso-db:/db`) with non-root users (e.g. `--user=2000:2000`).

For example:
```
$ mkdir config
$ sed 's,comments.db,/db/\0,g' contrib/isso.sample.cfg > config/isso.cfg 
$ docker run --user 2000:2000 --rm --name isso -p 127.0.0.1:8080:8080 \ 
    -v $PWD/config:/config -v /db ghcr.io/isso-comments/isso:0.13.0
Traceback (most recent call last):
  File "/isso/bin/gunicorn", line 8, in <module>
    sys.exit(run())
  File "/isso/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 67, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/isso/lib/python3.10/site-packages/gunicorn/app/base.py", line 231, in run
    super().run()
  File "/isso/lib/python3.10/site-packages/gunicorn/app/base.py", line 72, in run
    Arbiter(self).run()
  File "/isso/lib/python3.10/site-packages/gunicorn/arbiter.py", line 58, in __init__
    self.setup(app)
  File "/isso/lib/python3.10/site-packages/gunicorn/arbiter.py", line 118, in setup
    self.app.wsgi()
  File "/isso/lib/python3.10/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/isso/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/isso/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/isso/lib/python3.10/site-packages/gunicorn/util.py", line 359, in import_app
    mod = importlib.import_module(module)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/isso/isso/run.py", line 16, in <module>
    application = make_app(
  File "/isso/isso/__init__.py", line 185, in make_app
    isso = App(conf)
  File "/isso/isso/__init__.py", line 101, in __init__
    self.db = db.SQLite3(conf.get('general', 'dbpath'), conf)
  File "/isso/isso/db/__init__.py", line 32, in __init__
    rv = self.execute([
  File "/isso/isso/db/__init__.py", line 59, in execute
    with sqlite3.connect(self.path) as con:
sqlite3.OperationalError: unable to open database file
```

The reason that this change fixes the issue is that empty docker named/anonymous volumes are prepopulated with the container contents at the mount path, including owners and permissions.  Since `/db` does not exist a volume mounted there will use default owner of `root:root` and permissions `0755`, which is not writeable by a non-root user.

Note that this does not change the behavior of bind mounts, which always retain the permissions of the host filesystem.
