### PR TITLE
js: i18n: fix translation fallback to English

### DIFF
--- a/isso/js/app/i18n.js
+++ b/isso/js/app/i18n.js
@@ -133,7 +133,7 @@ if (!plural || !translations) {
 var translate = function(msgid) {
     return config[msgid + '-text-' + lang] ||
       translations[msgid] ||
-      en[msgid] ||
+      catalogue.en[msgid] ||
       "[?" + msgid + "]";
 };
 


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [ ] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Fix error when certain translation not present.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
When borwser's language is not English, and certain `msgid` dose not exist in target translation, we want provide the string in English, or `[?${msgid}]` format. But current implementation would just throw an error and interrupt the whole script, because `en` is not defined.