### PR TITLE
ext.notifications: Avoid error if headers are None

### DIFF
--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -168,7 +168,10 @@ class SMTP(object):
         if not subject:
             # Fallback, just in case as an empty subject does not work
             subject = 'isso notification'
+
         if uwsgi:
+            if not headers:
+                headers = ''
             uwsgi.spool({b"subject": subject.encode("utf-8"),
                          b"body": body.encode("utf-8"),
                          b"to": to.encode("utf-8"),


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] ~~(If adding features:) I have added tests to cover my changes~~
- [ ] ~~(If docs changes needed:) I have updated the **documentation** accordingly.~~
- [ ] ~~I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix~~
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
If using the uwsgi e-mail system, the attempt to do headers.encode() would cause an AttributeError if there were no headers. This pull request fixes this error.

## Why is this necessary?

```
2023-01-06 17:46:31,546 ERROR: POST /new
Traceback (most recent call last):
  File "isso/__init__.py", line 152, in dispatch
    response = handler(request.environ, request, **values)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "isso/views/comments.py", line 82, in dec
    return func(self, env, req, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "isso/views/__init__.py", line 43, in dec
    return func(cls, env, req, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "isso/views/comments.py", line 331, in new
    self.signal("comments.new:after-save", thread, rv)
  File "isso/ext/__init__.py", line 17, in __call__
    subscriber(*args, **kwargs)
  File "isso/ext/notifications.py", line 141, in notify_new
    self.sendmail(subject, body, thread, comment, None)
  File "isso/ext/notifications.py", line 175, in sendmail
    b"headers": headers.encode("utf-8")})
                ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'encode'
```