### PR TITLE
docs: testing-client: Fix typo in make command

### DIFF
--- a/docs/docs/technical-docs/testing-client.rst
+++ b/docs/docs/technical-docs/testing-client.rst
@@ -34,7 +34,7 @@ Then run the unit tests:
 
 .. code-block:: bash
 
-   $ npm run tests-unit
+   $ npm run test-unit
 
 You should receive output that looks similar to the following:
 


### PR DESCRIPTION
Fix typo in Doc
What changes does this Pull Request introduce?
This fixes incorrect documentation for running unit test: `npm run test-unit` from `npm run tests-unit`

Why is this necessary?
Currently the doc is incorrect and will not run unit tests