### PR TITLE
Avoid an error if `Offset.update()` hasn't been called yet.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,7 @@ Bugfixes & Improvements
 - Disable Postbox submit button on click, enable after response (`#993`_, pkvach)
 - Document title parameter and improve error handling for /new API (`#1058`_, pkvach)
 - Set reply sorting to always be oldest (`#1035`_, ggtylerr)
+- Fix ``Offset.localTime()`` failing if ``Offset.update()`` hasn't been called yet.
 
 .. _#951: https://github.com/posativ/isso/pull/951
 .. _#967: https://github.com/posativ/isso/pull/967

--- a/isso/js/app/globals.js
+++ b/isso/js/app/globals.js
@@ -10,7 +10,7 @@ Offset.prototype.update = function(remoteTime) {
 
 Offset.prototype.localTime = function() {
     return new Date((new Date()).getTime() - this.values.reduce(
-        function(a, b) { return a + b; }) / this.values.length);
+        function(a, b) { return a + b; }, 0) / this.values.length);
 };
 
 var offset = new Offset();


### PR DESCRIPTION
Closes #1069.

<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
This fixes a bug where `Offset.localTime()` will throw an error if called before `Offset.update()`.

## Why is this necessary?
#1069
