### PR TITLE
docs: Update installation docs for newer versions of Fedora

### DIFF
--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -100,6 +100,13 @@ Similar for Fedora (and derivates):
     $ sudo yum install python3-devel python3-virtualenv sqlite
     $ sudo yum groupinstall “Development Tools”
 
+For newer versions of Fedora (and derivatives) which use `dnf5`:
+
+.. code-block:: console
+
+    $ sudo dnf5 install python3-devel python3-virtualenv sqlite
+    $ sudo dnf5 group install development-tools
+
 Installation
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
## Checklist
- [ ] All new and existing **tests are passing** (n/a)
- [ ] (If adding features:) I have added tests to cover my changes (n/a)
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix (no)
- [x] I have written **proper commit message(s)**

## What changes does this Pull Request introduce?

Update installation steps to cover newer versions of Fedora and derivatives.

## Why is this necessary?

Fedora has recently dropped support for legacy `yum`; `yum` is now an alias to `dnf5`. The syntax and package names for group installs have changed as a result, which affects the setup steps in the manual.