### PR TITLE
ci: Add manual Docker rebuild workflow

### DIFF
--- a/.github/workflows/docker-rebuild.yaml
+++ b/.github/workflows/docker-rebuild.yaml
@@ -1,0 +1,70 @@
+name: Docker Rebuild (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to rebuild (e.g., 0.13.0, 0.12.6)'
+        required: true
+        type: string
+      update_release_tag:
+        description: 'Update the :release tag to point to this version'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  build_platforms: ${{ vars.BUILD_PLATFORMS || 'linux/amd64,linux/arm64/v8' }}
+  build_image: ${{ vars.BUILD_IMAGE || 'ghcr.io/isso-comments/isso' }}
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout specific version
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Validate version tag
+        run: |
+          if ! git describe --exact-match --tags HEAD 2>/dev/null; then
+            echo "Error: ${{ inputs.version }} is not a valid tag"
+            exit 1
+          fi
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          flavor: |
+            latest=false
+          images: ${{ env.build_image }}
+          tags: |
+            type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=raw,value=release,enable=${{ inputs.update_release_tag }}
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ env.build_platforms }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION


<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
This PR adds a new GitHub Actions workflow for manually rebuilding Docker images for specific release versions.

It allows maintainers to manually trigger a rebuild of Docker images for any existing release tag without creating a new release.

To try out the changes:

1. Go to the **Actions** tab on GitHub.
2. Select the "Docker Rebuild (Manual)" workflow.
3. Click "Run workflow," enter the desired version tag, and (optionally) enable updating the :release tag.
4. Monitor the workflow run for build and push results.

This workflow complements the existing [docker-build.yaml](https://github.com/isso-comments/isso/blob/master/.github/workflows/docker-build.yaml) workflow. 

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Related: #1061