### PR TITLE
docs: mistune: Remove incorrect claim about fenced code blocks

### DIFF
--- a/docs/docs/guides/mistune.rst
+++ b/docs/docs/guides/mistune.rst
@@ -47,13 +47,6 @@ If you want to have the same rendered result with Mistune, use underscores for e
 
 3. \*\*word1\*\*\_word2\_: Strong **word1** and emphasized *word2*
 
-Fenced code
-^^^^^^^^^^^
-
-In Misaka, fenced code can be marked by enclosing the code block in three backticks
-``````` or by putting four space characters in front of each code line. Mistune
-only understands three backticks.
-
 Plugins
 -------
 


### PR DESCRIPTION
The guide claimed Mistune only understands three backticks, but it actually supports 4-space indented code blocks too.

    import mistune
    md = mistune.create_markdown(escape=True)
    md('    indented code block\n    second line\n')
    md('```\nbacktick fenced\n```\n')

Both render as `<pre><code>...</code></pre>`.

<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [X] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [X] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->
