### PR TITLE
js, config: Add option to show/hide website field in comment form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog for Isso
 ==================
 
+%(version)s (%(date)s)
+--------------------
+
+New Features
+^^^^^^^^^^^^
+
+- Add option to show/hide website field in comment form (`#1111`_, pkvach)
+
+.. _#1111: https://github.com/isso-comments/isso/pull/1111
+
 0.14.0 (2026-03-26)
 --------------------
 

--- a/docs/docs/reference/server-config.rst
+++ b/docs/docs/reference/server-config.rst
@@ -348,6 +348,7 @@ for IPv4, ``/48`` for IPv6).
     reply-to-self = false
     require-author = false
     require-email = false
+    website-field = true
 
 enabled
     Enable guard, recommended in production. Not useful for debugging
@@ -384,6 +385,14 @@ require-email
     performed on the provided value.
 
     Default: ``false``
+
+website-field
+    Whether to show the website input field in the comment form. Set to
+    ``false`` to hide the website field entirely (no CSS hacks needed).
+
+    Default: ``true``
+
+    .. versionadded:: 0.14.1
 
 .. _configure-markup:
 

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -195,6 +195,10 @@ require-author = false
 # done on the provided address). Do not forget to configure the client.
 require-email = false
 
+# Whether to show the website input field in the comment form.
+# Set to false to hide the website field entirely.
+website-field = true
+
 
 [markup]
 # Customize markup and sanitized HTML. Currently, only Markdown (via mistune or misaka) is

--- a/isso/js/app/isso.js
+++ b/isso/js/app/isso.js
@@ -17,7 +17,7 @@ var Postbox = function(parent) {
         el = $.htmlify(template.render("postbox", {
         "author":  JSON.parse(localStorage.getItem("isso-author")),
         "email":   JSON.parse(localStorage.getItem("isso-email")),
-        "website": JSON.parse(localStorage.getItem("isso-website")),
+        "website": config["website-field"] !== false ? JSON.parse(localStorage.getItem("isso-website")) : null,
         "preview": ''
     }));
 
@@ -103,7 +103,8 @@ var Postbox = function(parent) {
 
         var author = $("[name=author]", el).value || null,
             email = $("[name=email]", el).value || null,
-            website = $("[name=website]", el).value || null;
+            websiteEl = config["website-field"] !== false ? $('[name=website]', el) : null,
+            website = websiteEl ? websiteEl.value || null : null;
 
         try {
             localStorage.setItem("isso-author", JSON.stringify(author));

--- a/isso/js/app/templates/postbox.js
+++ b/isso/js/app/templates/postbox.js
@@ -28,10 +28,10 @@ var html = function (globals) {
       + "<label for='isso-postbox-email'>" + i18n('postbox-email') + "</label>"
       + "<input id='isso-postbox-email' type='email' name='email' placeholder='" + i18n('postbox-email-placeholder') + "' value='" + (email ? email : '') + "' />"
     + "</p>"
-    + "<p class='isso-input-wrapper'>"
+    + (conf["website-field"] !== false ? "<p class='isso-input-wrapper'>"
       + "<label for='isso-postbox-website'>" + i18n('postbox-website') + "</label>"
       + "<input id='isso-postbox-website' type='text' name='website' placeholder='" + i18n('postbox-website-placeholder') + "' value='" + (website ? website : '') + "' />"
-    + "</p>"
+    + "</p>" : "")
     + "<p class='isso-post-action'>"
       + "<input type='submit' value='" + i18n('postbox-submit') + "' />"
     + "</p>"

--- a/isso/js/tests/unit/postbox-website-field.test.js
+++ b/isso/js/tests/unit/postbox-website-field.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* Keep the above exactly as-is!
+ * https://jestjs.io/docs/configuration#testenvironment-string
+ * https://jestjs.io/docs/configuration#testenvironmentoptions-object
+ */
+
+"use strict";
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = '';
+});
+
+test('Website field hidden when website-field=false', () => {
+  document.body.innerHTML =
+    '<div id="isso-thread"></div>' +
+    '<script src="http://isso.api/js/embed.min.js" data-isso="/"></script>';
+
+  const isso = require("app/isso");
+  const $ = require("app/dom");
+
+  const config = Object.assign({}, require("app/config"), {'website-field': false});
+
+  const i18n = require("app/i18n");
+  const svg = require("app/svg");
+  const template = require("app/template");
+
+  template.set("conf", config);
+  template.set("i18n", i18n.translate);
+  template.set("pluralize", i18n.pluralize);
+  template.set("svg", svg);
+
+  const isso_thread = $('#isso-thread');
+  isso_thread.append('<div id="isso-root"></div>');
+  isso_thread.append(new isso.Postbox(null));
+
+  // Website input should not be present
+  expect(document.querySelector('#isso-postbox-website')).toBeNull();
+  expect(document.querySelector('[name=website]')).toBeNull();
+
+  // Author and email fields should still be present
+  expect(document.querySelector('#isso-postbox-author')).not.toBeNull();
+  expect(document.querySelector('#isso-postbox-email')).not.toBeNull();
+});
+
+test('Website field shown when website-field=true (default)', () => {
+  document.body.innerHTML =
+    '<div id="isso-thread"></div>' +
+    '<script src="http://isso.api/js/embed.min.js" data-isso="/"></script>';
+
+  const isso = require("app/isso");
+  const $ = require("app/dom");
+
+  const config = Object.assign({}, require("app/config"), {'website-field': true});
+
+  const i18n = require("app/i18n");
+  const svg = require("app/svg");
+  const template = require("app/template");
+
+  template.set("conf", config);
+  template.set("i18n", i18n.translate);
+  template.set("pluralize", i18n.pluralize);
+  template.set("svg", svg);
+
+  const isso_thread = $('#isso-thread');
+  isso_thread.append('<div id="isso-root"></div>');
+  isso_thread.append(new isso.Postbox(null));
+
+  // Website input should be present
+  expect(document.querySelector('#isso-postbox-website')).not.toBeNull();
+  expect(document.querySelector('[name=website]')).not.toBeNull();
+});

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -199,6 +199,10 @@ class API(object):
         self.public_conf["reply-to-self"] = isso.conf.getboolean("guard", "reply-to-self")
         self.public_conf["require-email"] = isso.conf.getboolean("guard", "require-email")
         self.public_conf["require-author"] = isso.conf.getboolean("guard", "require-author")
+        try:
+            self.public_conf["website-field"] = isso.conf.getboolean("guard", "website-field")
+        except NoOptionError:
+            self.public_conf["website-field"] = True
         self.public_conf["reply-notifications"] = isso.conf.getboolean("general", "reply-notifications")
         self.public_conf["gravatar"] = isso.conf.getboolean("general", "gravatar")
 


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Add a configuration option `website-field` to control whether the Website input is shown in the comment form. When set to `false`, the website field is hidden without CSS hacks. 
Default is `true` for backward compatibility.

<details><summary>Example</summary>
<p>

<img width="647" height="321" alt="image" src="https://github.com/user-attachments/assets/839951e3-221d-473e-9259-5fb31d5627d3" />

</p>
</details> 

To verify, set `website-field = false` in the config and reload the comment form, the website field shouldn’t show up.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Closes https://github.com/isso-comments/isso/issues/916
